### PR TITLE
Bug 278 : Resolved Issue on Permission Tree New Component

### DIFF
--- a/raaghu-components/src/rds-comp-permission-tree-new/rds-comp-permission-tree-new.tsx
+++ b/raaghu-components/src/rds-comp-permission-tree-new/rds-comp-permission-tree-new.tsx
@@ -12,8 +12,8 @@ function TreeNode(props: any) {
     useEffect(() => {
         // Update the state of this node based on its children
         if (hasChildren) {
-            const allChildrenSelected = props.node.children.every((child: any) => child.selected);
-            setChecked(allChildrenSelected);
+            const updatedChildren = props.node.children.some((child: any) => child.selected);
+            setChecked(updatedChildren);
         }
     }, [props.node.children]);
 
@@ -117,6 +117,14 @@ function RdsCompPermissionTreeNew(props: RdsCompPermissionTreeProps) {
             } else if (node.children && node.children.length > 0) {
                 // Recursively update the state of child nodes
                 const updatedChildren = updateNodeState(node.children, targetNode, isChecked);
+                node.children = updatedChildren;
+                // If any child is selected, select the parent node
+                if (updatedChildren.some((child: any) => child.selected)) {
+                    node.selected = true;
+                } else {
+                    // If none of the grandchildren are selected, deselect the parent node
+                    node.selected = false;
+                }
                 return { ...node, children: updatedChildren };
             }
             return node;


### PR DESCRIPTION
## Description
> Resolve the issues on Permission Tree New Component: 
-  **Permission Tree New**

> Make the changes to rds-comp-permission-tree-new.tsx file.
> Resolved issue of once child node or grandchild node is selected parent node is expected to select.

## Screenshots :
 
![image](https://github.com/Wai-Technologies/raaghu-react/assets/155605401/14cdbe4b-2dfc-40d5-8305-cfd0a22a7db0)

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes