### PR TITLE
Resolved Bug 630 : Banner > Space is missing between word News and !

### DIFF
--- a/raaghu-elements/src/rds-banner/rds-banner.stories.tsx
+++ b/raaghu-elements/src/rds-banner/rds-banner.stories.tsx
@@ -32,7 +32,7 @@ type Story = StoryObj<typeof RdsBanner>;
 export const Banner: Story = {
     args: {
         textAlign: "start",
-        bannerText: "Big news! We are excited to announce a brand new product.",
+        bannerText: "Big news ! We are excited to announce a brand new product.",
         sticky: false,
         position: "top",
         colorVariant: "info",


### PR DESCRIPTION
## Description

1. Added space after the news word

## Screenshots:

![image](https://github.com/user-attachments/assets/bc911fee-ec6d-493b-8418-806a0fb436a1)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
