### PR TITLE
Resolved bug 420: Storybook > Component >Login > Default > Tablet view chevron is not visible proper.  

### DIFF
--- a/raaghu-components/src/rds-comp-login/rds-comp-login.tsx
+++ b/raaghu-components/src/rds-comp-login/rds-comp-login.tsx
@@ -121,11 +121,11 @@ const RdsCompLogin = (props: RdsCompLoginProps) => {
       <div className="">
         <div className="text-center">
         <div className="container">
-          <div className="row align-items-center mb-1">
+          <div className="row align-items-center mb-1 mx-md-1">
             <div className="col-12 col-md-11 text-center mb-3">
               <h2 className="mb-0 ms-4">Login</h2>
             </div>
-            <div className="col-12 col-md-1 text-center text-md-end mb-3">
+            <div className="col-12 col-md-1 text-center text-md-end mb-3 px-md-0 px-lg-4">
               <RdsDropdownList
                 labelIcon={currentLanguageIcon}
                 labelIconWidth="18px"


### PR DESCRIPTION
## Description
> Resolved issues on Login Component>Table View:
-  **Select Language dropdown position**
> Make the changes to Login Component.

## Screenshots :
![420](https://github.com/user-attachments/assets/d699053a-0811-4465-b7ec-b6cf65a07437)
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes