### PR TITLE
Resolved Bug 715 :  Design System > Components > Get Assistance > Default > Fill the required field. NEXT button is not enabled.

### DIFF
--- a/raaghu-components/src/rds-comp-get-assistance/rds-comp-get-assistance.tsx
+++ b/raaghu-components/src/rds-comp-get-assistance/rds-comp-get-assistance.tsx
@@ -68,7 +68,7 @@ const RdsCompGetAssistance = (props: RdsCompGetAssistanceProps) => {
                   label="Name"
                   labelPosition="top"
                   placeholder="Enter Name"
-                  // required
+                  required={true}
                   readonly={false}
                   isDisabled={false}
                   size="medium"

--- a/raaghu-components/src/rds-comp-webhook-subscriptions/rds-comp-webhook-subscriptions.tsx
+++ b/raaghu-components/src/rds-comp-webhook-subscriptions/rds-comp-webhook-subscriptions.tsx
@@ -5,6 +5,7 @@ import {
     RdsIllustration,
     RdsInput,
     RdsTextArea,
+    RdsLabel,
 } from "../rds-elements";
 
 export interface RdsCompWebhookSubscriptionProps {
@@ -64,7 +65,7 @@ const RdsCompWebhookSubscription = (props: RdsCompWebhookSubscriptionProps) => {
 
     const isFormValid =
         isEndpointValid(user.endpoint) &&
-        isEventValid(user.event) &&
+       
         webhookheaderfile.length != 0;
 
     //****************handle Submit********************
@@ -155,7 +156,12 @@ const RdsCompWebhookSubscription = (props: RdsCompWebhookSubscriptionProps) => {
                     </div>
 
                      <div className="fw-normal row mb-3 mt-2 align-items-center">              
-                        <label className="mb-2" id="webhookEndpoint">Additional Webhook Headers</label>
+                        {/* <label className="mb-2" id="webhookEndpoint">Additional Webhook Headers</label> */}
+                        <RdsLabel
+                           label="Additional Webhook Headers"
+                           id="webhookEndpoint"
+                           required={true}
+                        />
                         <div className="col-12 col-md-5 mb-3">
                             <RdsInput
                                 placeholder="Header key"
@@ -166,6 +172,7 @@ const RdsCompWebhookSubscription = (props: RdsCompWebhookSubscriptionProps) => {
                                   handleDataChanges(e.target.value, "headerKey");
                                 }}
                                 value={user?.headerKey}
+                                
                                 dataTestId="header-key"
                             ></RdsInput>
                         </div>
@@ -175,6 +182,7 @@ const RdsCompWebhookSubscription = (props: RdsCompWebhookSubscriptionProps) => {
                                 reset={inputReset}
                                 inputType="text"
                                 name={"headerValue"}
+                               
                                 onChange={(e) => {
                                   handleDataChanges(e.target.value, "headerValue");
                                 }}


### PR DESCRIPTION
## Description
> Resolve the issues on: 
-  **Get Assistance **
-  **Webhook Subscription**
> Make the changes to .tsx file.
> Change Name field to required in Get-Assistance component.
> Webhook Event validation for disable save button removed.

## Screenshots :
![image](https://github.com/user-attachments/assets/d50a5724-b67d-4ba2-8713-5c70c24bfc62)
![image](https://github.com/user-attachments/assets/be76b3ae-f562-4b33-809f-c7b51c0405b3)

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes