### PR TITLE
Resolved Bug 731 : Storybook > Component > Feeds & Reviews > Month text is not as per wireframe

### DIFF
--- a/raaghu-components/src/rds-comp-feeds/rds-comp-feeds.tsx
+++ b/raaghu-components/src/rds-comp-feeds/rds-comp-feeds.tsx
@@ -48,7 +48,11 @@ const RdsCompFeeds = (props: RdsCompFeedProps) => {
                                                 "text-muted text-end flex-grow-1 "
                                             }
                                         >
-                                            {item.date.toDateString().slice(4)}
+                                            {item.date.toLocaleDateString('en-GB', {
+                                                day: '2-digit',
+                                                month: 'long',
+                                                year: 'numeric'
+                                            }).replace(/ (\d{4})/, ', $1')}
                                         </div>
                                     )}
                                 </div>
@@ -104,8 +108,12 @@ const RdsCompFeeds = (props: RdsCompFeedProps) => {
                                         </span>
                                     )}
                                     {item.date && (
-                                        <div className={"text-muted  flex-grow-1 "}>
-                                            {item.date.toDateString().slice(4)}
+                                        <div className={"text-muted flex-grow-1 "}>
+                                            {item.date.toLocaleDateString('en-GB', {
+                                                day: '2-digit',
+                                                month: 'long',
+                                                year: 'numeric'
+                                            }).replace(/ (\d{4})/, ', $1')}
                                         </div>
                                     )}
                                 </div>

--- a/raaghu-components/src/rds-comp-feeds/rds-comp-feeds.tsx
+++ b/raaghu-components/src/rds-comp-feeds/rds-comp-feeds.tsx
@@ -45,7 +45,7 @@ const RdsCompFeeds = (props: RdsCompFeedProps) => {
                                     {item.date && (
                                         <div
                                             className={
-                                                "text-muted text-end text-lowercase flex-grow-1 "
+                                                "text-muted text-end flex-grow-1 "
                                             }
                                         >
                                             {item.date.toDateString().slice(4)}

--- a/raaghu-components/src/rds-comp-feeds/rds-comp-feeds.tsx
+++ b/raaghu-components/src/rds-comp-feeds/rds-comp-feeds.tsx
@@ -104,7 +104,7 @@ const RdsCompFeeds = (props: RdsCompFeedProps) => {
                                         </span>
                                     )}
                                     {item.date && (
-                                        <div className={"text-muted text-lowercase flex-grow-1 "}>
+                                        <div className={"text-muted  flex-grow-1 "}>
                                             {item.date.toDateString().slice(4)}
                                         </div>
                                     )}

--- a/raaghu-elements/src/rds-review-category/rds-review-category.tsx
+++ b/raaghu-elements/src/rds-review-category/rds-review-category.tsx
@@ -36,7 +36,11 @@ const RdsReviewCategory = (props: RdsReviewCategoryProps) => {
                                     />
                                     {props.item.date && (
                                         <p className="mt-2 text-secondary">
-                                            {props.item.date.toDateString().slice(4)}
+                                            {props.item.date.toLocaleDateString('en-GB', {
+                                                day: '2-digit',
+                                                month: 'long',
+                                                year: 'numeric'
+                                            }).replace(/ (\d{4})/, ', $1')}
                                         </p>
                                     )}
                                 </div>


### PR DESCRIPTION
## Description
> Resolve the issues on Component : 
-**Feeds**
-**Reviews**
-  The date format is not as per wireframe

## Screenshots :
![image](https://github.com/user-attachments/assets/50b71bd9-84ed-4fb7-8bd8-04050fc6562e)
![image](https://github.com/user-attachments/assets/399531c8-a7c6-4365-92b4-d92540d0ec52)


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes