### PR TITLE
Resolved Bug 722 : Design System > Input type number is not present at all in raaghu element

### DIFF
--- a/raaghu-elements/src/rds-input/rds-input.stories.tsx
+++ b/raaghu-elements/src/rds-input/rds-input.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta = {
             control: { type: "select" },
         },
         inputType: {
-            options: ["email", "text", "password", "otp"],
+            options: ["email", "text", "password", "otp","number"],
             control: { type: "select" },
         },
         labelPosition: {


### PR DESCRIPTION
## Description
Input type number is not present at all in raaghu element

Fixes # (issue)
Type Number added



## How Has This Been Tested?

Design System-> Elements->input 
 The inputy type number option visible in the dropdown
![input typ number](https://github.com/user-attachments/assets/cdfa1fef-55ae-49d7-824f-215074372535)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
