### PR TITLE
Resolved Bug  522 : Storybook >Charts>Scatter Chart>Docs> Scatter Chart icon does not display proper

### DIFF
--- a/raaghu-elements/src/rds-chart-scatter/rds-chart-scatter.stories.tsx
+++ b/raaghu-elements/src/rds-chart-scatter/rds-chart-scatter.stories.tsx
@@ -17,7 +17,6 @@ const meta: Meta = {
 export default meta;
 type Story = StoryObj<typeof RdsScatterChart>;
 
-
 export const ScatterChart: Story = {
     args: {
         id: "Scatter Chart",
@@ -37,8 +36,8 @@ export const ScatterChart: Story = {
                     { x: 0.5, y: 5.5 }
                 ],
                 backgroundColor: "rgb(255, 99, 132)",
-                pointStyle: 'triangle',  // Set pointStyle to triangle
-           
+                pointStyle: 'triangle', // Set pointStyle to triangle
+                pointRadius: 8, // Set pointRadius to increase icon size
             }
         ],
         labels: ["January", "February", "March", "April"],
@@ -67,7 +66,6 @@ export const ScatterChart: Story = {
     }
 };
 
-
 export const ScatterChartWithMultiAxis: Story = {
     args: {
         id: "Radar Chart",
@@ -77,22 +75,10 @@ export const ScatterChartWithMultiAxis: Story = {
             {
                 label: "Scatter Dataset 1",
                 data: [
-                    {
-                        x: -10,
-                        y: 0
-                    },
-                    {
-                        x: 0,
-                        y: 10
-                    },
-                    {
-                        x: 9,
-                        y: 5
-                    },
-                    {
-                        x: 0.5,
-                        y: 5.5
-                    }
+                    { x: -10, y: 0 },
+                    { x: 0, y: 10 },
+                    { x: 9, y: 5 },
+                    { x: 0.5, y: 5.5 }
                 ],
                 backgroundColor: "rgb(255, 99, 132)",
                 yAxisID: "y",
@@ -100,29 +86,16 @@ export const ScatterChartWithMultiAxis: Story = {
             {
                 label: "Scatter Dataset 2",
                 data: [
-                    {
-                        x: -20,
-                        y: 9
-                    },
-                    {
-                        x: 10,
-                        y: -10
-                    },
-                    {
-                        x: 20,
-                        y: 15
-                    },
-                    {
-                        x: 1.5,
-                        y: 15.5
-                    }
+                    { x: -20, y: 9 },
+                    { x: 10, y: -10 },
+                    { x: 20, y: 15 },
+                    { x: 1.5, y: 15.5 }
                 ],
                 backgroundColor: "rgb(155, 99, 132)",
                 yAxisID: "y",
             }
         ],
         labels: ["January", "February", "March", "April"],
-
         options: {
             responsive: true,
             maintainAspectRatio: false,
@@ -137,14 +110,14 @@ export const ScatterChartWithMultiAxis: Story = {
             },
             scales: {
                 y: {
-                    type: "linear", // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
+                    type: "linear",
                     position: "left",
                     ticks: {
                         color: "red"
                     }
                 },
                 y2: {
-                    type: "linear", // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
+                    type: "linear",
                     position: "right",
                     reverse: true,
                     ticks: {


### PR DESCRIPTION
## Description
Scatter chart icon size issue small. 


Fixes # (issue)
Size  changed

## Type of change
Changed in the story file

## How Has This Been Tested?

Goto Charts->Scatter chart

![scattercharticonenlarged](https://github.com/user-attachments/assets/358b4033-6023-4f4c-8f2e-c97a2e1ec555)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
