### PR TITLE
Resolved Bug 676 : Pagination Dropdown alignment issue fixed

### DIFF
--- a/raaghu-elements/src/rds-pagination/rds-pagination.stories.tsx
+++ b/raaghu-elements/src/rds-pagination/rds-pagination.stories.tsx
@@ -38,8 +38,8 @@ type Story = StoryObj<typeof RdsPagination>;
 export const Default: Story = {
     args: {
         paginationType: "default",
-        totalRecords: 10,
-        recordsPerPage: 3,
+        totalRecords: 10,  // Ensure this value matches your test cases
+        recordsPerPage: 3, // This will yield 4 pages total
         size: "small",
         alignmentType: "start",
     }
@@ -56,4 +56,3 @@ export const Advanced: Story = {
     }
 } satisfies Story;
 Advanced.parameters = { controls: { include: ['paginationType', 'totalRecords', 'recordsPerPage', 'size', 'alignmentType'] } };
-

--- a/raaghu-elements/src/rds-pagination/rds-pagination.tsx
+++ b/raaghu-elements/src/rds-pagination/rds-pagination.tsx
@@ -23,7 +23,7 @@ const RdsPagination = (props: RdsPaginationProps) => {
   const [totalRecords, setTotalRecords] = useState(props.totalRecords);
   const [recordsPerPage, setRecordsPerPage] = useState(props.recordsPerPage || 10);
   const [selectedRecordsPerPage, setSelectedRecordsPerPage] = useState(props.recordsPerPage || 10);
-  
+
   const paginType = props.paginationType || "default";
   const dropdownButtonRef = useRef(null);
   const values = [10, 25, 50, 100];
@@ -185,100 +185,100 @@ const RdsPagination = (props: RdsPaginationProps) => {
           </nav>
         )}
 
-{paginType === "advanced" && (
-  <nav aria-label="page navigation" className={"d-flex align-items-baseline" + `${align}`}>
-    <ul className={"pagination rounded align-items-center mb-0" + `${size}` + `${align}`}>
-      {/* Previous Page Button */}
-      <li className={`m-1 page-item chevron cursor-pointer ${currentPage === 1 ? "disabled" : ""}`}>
-        <a onClick={() => onPrevious(currentPage)}>
-          {totalRecords > recordsPerPage && (
-            <RdsIcon
-              name="chevron_left"
-              width="15px"
-              height="15px"
-              fill={false}
-              stroke={true}
-              colorVariant="primary"
-            />
-          )}
-        </a>
-      </li>
+        {paginType === "advanced" && (
+          <nav aria-label="page navigation" className={"d-flex align-items-center" + `${align}`}>
+            <ul className={"pagination rounded align-items-center mb-0" + `${size}` + `${align}`}>
+              {/* Previous Page Button */}
+              <li className={`m-1 page-item chevron cursor-pointer ${currentPage === 1 ? "disabled" : ""}`}>
+                <a onClick={() => onPrevious(currentPage)}>
+                  {totalRecords > recordsPerPage && (
+                    <RdsIcon
+                      name="chevron_left"
+                      width="15px"
+                      height="15px"
+                      fill={false}
+                      stroke={true}
+                      colorVariant="primary"
+                    />
+                  )}
+                </a>
+              </li>
 
-      {/* Displayed Pages */}
-      {previous.map((number, index) => (
-        <li
-          key={number}
-          className={`m-1 page-item ${typeof number === 'number' ? (number === currentPage ? "active" : "") : ""}`}
-        >
-          <a onClick={() => typeof number === 'number' && onPage(number)}>
-            {number}
-          </a>
-        </li>
-      ))}
+              {/* Displayed Pages */}
+              {previous.map((number, index) => (
+                <li
+                  key={number}
+                  className={`m-1 page-item ${typeof number === 'number' ? (number === currentPage ? "active" : "") : ""}`}
+                >
+                  <a onClick={() => typeof number === 'number' && onPage(number)}>
+                    {number}
+                  </a>
+                </li>
+              ))}
 
-      {/* Continued Pages */}
-      {continued.map((number, index) => (
-        <li
-          key={number}
-          className={`m-1 page-item ${typeof number === 'number' ? (number === currentPage ? "active" : "") : ""}`}
-        >
-          <a onClick={() => typeof number === 'number' && onPage(number)}>
-            {number}
-          </a>
-        </li>
-      ))}
+              {/* Continued Pages */}
+              {continued.map((number, index) => (
+                <li
+                  key={number}
+                  className={`m-1 page-item ${typeof number === 'number' ? (number === currentPage ? "active" : "") : ""}`}
+                >
+                  <a onClick={() => typeof number === 'number' && onPage(number)}>
+                    {number}
+                  </a>
+                </li>
+              ))}
 
-      {/* Next Page Button */}
-      <li className={`m-1 page-item chevron ${currentPage === int ? "disabled" : ""}`}>
-        <a onClick={() => onNext(currentPage)}>
-          {totalRecords > recordsPerPage && (
-            <RdsIcon
-              name="chevron_right"
-              width="15px"
-              height="15px"
-              fill={false}
-              stroke={true}
-              colorVariant="primary"
-            />
-          )}
-        </a>
-      </li>
-    </ul>
+              {/* Next Page Button */}
+              <li className={`m-1 page-item chevron ${currentPage === int ? "disabled" : ""}`}>
+                <a onClick={() => onNext(currentPage)}>
+                  {totalRecords > recordsPerPage && (
+                    <RdsIcon
+                      name="chevron_right"
+                      width="15px"
+                      height="15px"
+                      fill={false}
+                      stroke={true}
+                      colorVariant="primary"
+                    />
+                  )}
+                </a>
+              </li>
+            </ul>
 
-    {/* Dropdown for Records Per Page */}
-    <div className="dropdown custom-navigation">
-      <button
-        className="btn customWidthForBtn btn-outline border-primary"
-        id="paginationBtnId"
-        type="button"
-        data-bs-toggle="dropdown"
-        aria-expanded={isDropdownOpen}
-        onClick={toggleDropdown}
-        ref={dropdownButtonRef}
-      >
-        <div className="d-flex justify-content-between">
-          {selectedRecordsPerPage}
-          <span className="mt-0" onClick={toggleDropdown}>
-            <div style={{ pointerEvents: "none" }}>
-              <RdsIcon name={dropdownIcon} fill={false} stroke={true} height="12px" width="12px" />
+            {/* Dropdown for Records Per Page */}
+            <div className="dropdown custom-navigation">
+              <button
+                className="btn customWidthForBtn btn-outline border-primary"
+                id="paginationBtnId"
+                type="button"
+                data-bs-toggle="dropdown"
+                aria-expanded={isDropdownOpen}
+                onClick={toggleDropdown}
+                ref={dropdownButtonRef}
+              >
+                <div className="d-flex justify-content-between">
+                  {selectedRecordsPerPage}
+                  <span className="mt-0" onClick={toggleDropdown}>
+                    <div style={{ pointerEvents: "none" }}>
+                      <RdsIcon name={dropdownIcon} fill={false} stroke={true} height="12px" width="12px" />
+                    </div>
+                  </span>
+                </div>
+              </button>
+              <ul className={`dropdown-menu customWidthClass ${isDropdownOpen ? "show" : ""}`}>
+                {values.map((value) => (
+                  <li
+                    key={value}
+                    className={`pagination-item ${selectedRecordsPerPage === value ? "active" : ""}`}
+                    onClick={() => handleItemsPerPageChange(value)}
+                  >
+                    {value}
+                  </li>
+                ))}
+              </ul>
             </div>
-          </span>
-        </div>
-      </button>
-      <ul className={`dropdown-menu customWidthClass ${isDropdownOpen ? "show" : ""}`}>
-        {values.map((value) => (
-          <li
-            key={value}
-            className={`pagination-item ${selectedRecordsPerPage === value ? "active" : ""}`}
-            onClick={() => handleItemsPerPageChange(value)}
-          >
-            {value}
-          </li>
-        ))}
-      </ul>
-    </div>
-  </nav>
-)}
+          </nav>
+        )}
 
 
         {paginType === "onPagerPagination" && (

--- a/raaghu-react-themes/src/styles/pagination.scss
+++ b/raaghu-react-themes/src/styles/pagination.scss
@@ -1,6 +1,6 @@
 // /*pagination custom properties*/
 .pagination {
-  margin-top: 1%;
+  // margin-top: 1%;
 
   .page-item {
     margin: $pagination-item-margin-x;


### PR DESCRIPTION


## Description

Pagination Dropdown Alignment issue 

![pagination1](https://github.com/user-attachments/assets/f7f23a76-d0b2-4ba1-a396-e23f0bc47081)

Fixes # (issue)
CSS changes


## How Has This Been Tested?

Goto pagination-> in advanced story -> check the dropdown into a larger number to make one page link according to the record size. The alignment of pagination and dropdown is in same line
![page_resolved](https://github.com/user-attachments/assets/cc6d27ae-6099-4251-a3f3-fc8653448a3b)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
