### PR TITLE
Resolved Bug 789 : Design System > Elements > Scrollspy > Dark theme Go Top button is not visible

### DIFF
--- a/raaghu-elements/src/rds-scrollspy/rds-scrollspy.tsx
+++ b/raaghu-elements/src/rds-scrollspy/rds-scrollspy.tsx
@@ -37,8 +37,8 @@ const RdsScrollspy = (props: RdsScrollspyProps) => {
               <h4 className="contentHeader">{item.header}</h4>
               <p className="contentParagraph">{item.content}</p>
             </div>
-            <div className="d-flex justify-content-end align-items-end">
-              <a href="#scrollspy" target="_self" className="text-decoration-none">
+            <div className="d-flex justify-content-end align-items-end ">
+              <a href="#scrollspy" target="_self" className="text-decoration-none text-primary">
                 Go Top
               </a>
             </div>


### PR DESCRIPTION
## Description

> Changes for the issue with the text go home is not shown when dark mode is on

## ScreenShot 
Dark Mode
![image](https://github.com/user-attachments/assets/50d8d767-b635-4dbd-8743-c513f8c27ea8)

Light Mode 
![image](https://github.com/user-attachments/assets/8473766b-c302-4ce8-bcd3-27b65c31b53d)




## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
