### PR TITLE
Resolved Bug 789 : Design System > Elements > Scrollspy > Dark theme Go Top button is not visible.

### DIFF
--- a/raaghu-elements/src/rds-scrollspy/rds-scrollspy.css
+++ b/raaghu-elements/src/rds-scrollspy/rds-scrollspy.css
@@ -123,3 +123,9 @@
     margin-bottom: 10px;
   }
 }
+#scrollspy .nav-pills{
+  background-color: unset !important;
+}
+#scrollspy p{
+ color: black !important;
+}

--- a/raaghu-elements/src/rds-scrollspy/rds-scrollspy.tsx
+++ b/raaghu-elements/src/rds-scrollspy/rds-scrollspy.tsx
@@ -33,7 +33,7 @@ const RdsScrollspy = (props: RdsScrollspyProps) => {
       <div>
         {props.data.map((item) => (
           <div id={`scrollspyHeading${item.id}`} className="scrossSpyItem" key={item.id}>
-            <div>
+            <div id="scrollspy">
               <h4 className="contentHeader">{item.header}</h4>
               <p className="contentParagraph">{item.content}</p>
             </div>


### PR DESCRIPTION
## Description
> Changes done
1)FIRST, SECOND, THIRD Button is not display Proper.
2)Dark theme card text is not display proper.

## Screenshots :
![image](https://github.com/user-attachments/assets/06bc11b3-518c-4d33-9a46-d0177e0dd06d)



## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes