### PR TITLE
Resolved Bug 1216 : Design System > Elements > Accordion > Docs > Background color is showing to the chevron of first accordion

### DIFF
--- a/raaghu-elements/src/rds-accordion/rds-accordion.tsx
+++ b/raaghu-elements/src/rds-accordion/rds-accordion.tsx
@@ -90,24 +90,20 @@ const RdsAccordion = (props: RdsAccordionProps) => {
 
         return iconSpan;
     }
-    useEffect(() => {
-        openItemIds.forEach(id => {
-            const element = document.getElementById(`heading${id}`);
-            if (element) {
-                element.classList.add('accordion-active-bg');
-            }
-        });
 
-        return () => {
-            openItemIds.forEach(id => {
-                const element = document.getElementById(`heading${id}`);
-                if (element) {
+    useEffect(() => {
+        props.items.forEach(item => {
+            const element = document.getElementById(`heading${item.id}`);
+            if (element) {
+                if (openItemIds.includes(item.id)) {
+                    element.classList.add('accordion-active-bg');
+                } else {
                     element.classList.remove('accordion-active-bg');
                 }
-            });
-        };
-    }, [openItemIds]);
-
+            }
+        });
+    }, [openItemIds, props.items]);
+    
     return (
         <div id={`accordion${props.accordionId}`} ref={accordionRef}>
             <div className="accordion" id="accordionBasic">


### PR DESCRIPTION
## Description

> Resolved issue in elements:
1. Changes for Accordion -Doc- Background color is showing to the chevron of first accordion

-  **Accordion**

> Make the changes to rds-accordion.tsx

## Screenshots : 
![image](https://github.com/user-attachments/assets/29205cd1-b134-4463-9bb6-0e4572325fd2)


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes