### PR TITLE
Resolved Bug 1389 : Design System > Elements > Review Category > Center Aligned/Left Aligned Stories Profile Icon Is Enlarged

### DIFF
--- a/raaghu-elements/src/rds-review-category/rds-review-category.css
+++ b/raaghu-elements/src/rds-review-category/rds-review-category.css
@@ -4,6 +4,7 @@
 
 .RdsReviewCategory__review-type-1 .avatar {
     margin-bottom: 10px;
+    height: 40px;
 }
 .RdsReviewCategory__review-type-1 .item-name {
     margin-bottom: 12px;
@@ -31,6 +32,7 @@
 .RdsReviewCategory__review-type-1 .avatar img,
 .RdsReviewCategory__review-type-2 .avatar img {
     border-radius: 50%;
+    height: 40px;
 }
 
 .theme-dark svg {


### PR DESCRIPTION

## Description
>Resolve issue in Design System > Elements > Review Category > Center Aligned/Left Aligned
>Resolve issue Center Aligned/Left Aligned stories profile icon is display too big.

-**Resolved enlarged image issue by adding height in rds-review-category.css**

## Screenshots
![image](https://github.com/user-attachments/assets/ca3d60f9-d1bd-4907-82e6-9c9bdedee13c)
![image](https://github.com/user-attachments/assets/3a548895-b597-4573-85cd-17850ccdfa1f)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
