### PR TITLE
Resolved bug 1395: Elements >Notification > Default > Mark As Read button alignment issue.

### DIFF
--- a/raaghu-elements/src/rds-notification/rds-notification.tsx
+++ b/raaghu-elements/src/rds-notification/rds-notification.tsx
@@ -183,7 +183,7 @@ const RdsNotification = (props: RdsNotificationProps) => {
                         <hr className="m-0" />
                     </div>
                 ))}
-                <div className="d-flex justify-content-end m-3">
+                <div className="d-flex justify-content-end m-2">
                     <RdsButton
                         colorVariant="primary"
                         label="Mark As Read"


### PR DESCRIPTION
## Description
> 1395 Resolve issues in Elements >Notification > Default > Mark As Read button alignment issue.

-**Resolved issue by Mark As Read button alignment issue in changing by m-3 to m-2**


## Screenshot
![image](https://github.com/user-attachments/assets/53a8d03b-2123-4882-8bad-2b0d11589036)
![image](https://github.com/user-attachments/assets/22ffe693-7b0e-448f-b1eb-616173da03e4)
![image](https://github.com/user-attachments/assets/e70dc619-de62-432b-ae8d-ef8ab373c2f6)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
