### PR TITLE
Resolved Bug 1404 : Design System > Elements > Rating > The position of the rating stars is inconsistent after changing the count

### DIFF
--- a/raaghu-elements/src/rds-rating/rds-rating.tsx
+++ b/raaghu-elements/src/rds-rating/rds-rating.tsx
@@ -160,7 +160,7 @@ const RdsRating = (props: RdsRatingProps) => {
   return (
     <>
       {!props.defaultSlider && (
-        <div className={`starrating align-items-center d-flex gap-2 ${sizeClass}`}>
+        <div className={`align-items-center d-flex d-lg-flex d-md-block fs-5 gap-2 starrating ${sizeClass}`}>
           {!props.outline && !props.filled && !props.defaultSlider && (
             <div className="rating-container">
              <span className="fs-5 me-2 mt-2 rating-number">{rating}</span>

--- a/raaghu-elements/src/rds-review-category/rds-review-category.tsx
+++ b/raaghu-elements/src/rds-review-category/rds-review-category.tsx
@@ -75,7 +75,7 @@ const RdsReviewCategory = (props: RdsReviewCategoryProps) => {
 
             {props.item && props.display_type === "ReviewType_1" && (
                 <div className="RdsReviewCategory__review-type-1">
-                    <div className="row sm-d-flex">
+                    <div className="justify-content-between row sm-d-flex">
                         <div className="col-md-3">
                             <div className="avatar">
                                 <RdsAvatar
@@ -105,7 +105,7 @@ const RdsReviewCategory = (props: RdsReviewCategoryProps) => {
                                 />
                             </div>}
                         </div>
-                        <div className="col-md-8 pe-5">
+                        <div className="col-md-8 ">
                             <RdsLabel
                                 label={props.item.reviewTitle}
                                 multiline={true}


### PR DESCRIPTION
## Description
>Resolve issues in  Elements > Rating > The position of the rating stars is inconsistent after changing the count

-**Resolved issue by add a justify-content-between and remove the pe-5 in class**

>Resolve issues in Components > Grid > Overlapping issue 

## Screenshot
![image](https://github.com/user-attachments/assets/acc2d0b6-ffe7-4224-ac51-3474db2ee448)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
