### PR TITLE
Resolved Bug 1389 : Design System > Elements > Review Category > Center Aligned/Left Aligned Stories Profile Icon Is Enlarged Reopen issue solved

### DIFF
--- a/raaghu-elements/src/rds-label/rds-label.tsx
+++ b/raaghu-elements/src/rds-label/rds-label.tsx
@@ -23,7 +23,7 @@ const RdsLabel = (props: RdsLabelProps) => {
     const fontWeight = "fw-" + props.fontWeight
 
     return (<>
-        <p className={`d-flex  ${props.multiline ? ' text-break' : ' singleLine'}   ${props.class? props.class : ""}`}>
+        <p className={`d-flex p-0 m-0 ${props.multiline ? ' text-break' : ' singleLine'}   ${props.class? props.class : ""}`}>
             <label className={`form-label mb-0 ${fontWeight} ${isItalic}`} htmlFor={props?.id}
                 onClick={props.onClick}>{props.label}</label>
             {props.required && (

--- a/raaghu-elements/src/rds-rating/rds-rating.tsx
+++ b/raaghu-elements/src/rds-rating/rds-rating.tsx
@@ -160,7 +160,7 @@ const RdsRating = (props: RdsRatingProps) => {
   return (
     <>
       {!props.defaultSlider && (
-        <div className={`align-items-center d-flex d-lg-flex fs-5 gap-2 starrating ${sizeClass}`}>
+        <div className={`align-items-center d-flex d-lg-flex fs-5 gap-1 starrating ${sizeClass}`}>
           {!props.outline && !props.filled && !props.defaultSlider && (
             <div className="rating-container">
              <span className="fs-5 me-2 mt-2 rating-number">{rating}</span>


### PR DESCRIPTION
## Description
>Resolve issue in Design System > Elements > Review Category > Center Aligned/Left Aligned
>Resolve issue Center Aligned/Left Aligned stories profile icon is display too big.

-**Resolved enlarged image issue by adding height in rds-review-category.css**
-**Resolved spacing issue in side text**
-**Resolved stars spacing issue**

## Screenshots
![image](https://github.com/user-attachments/assets/2241ab3c-fe48-4c42-be0d-2c3467f5c182)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

