### PR TITLE
Resolved Bug 823: Design System > Create color variants for toast elements.

### DIFF
--- a/raaghu-elements/src/rds-toast/rds-toast.tsx
+++ b/raaghu-elements/src/rds-toast/rds-toast.tsx
@@ -44,7 +44,7 @@ const RdsToast = (props: RdsToastProps) => {
 
     const classes = () => {
         switch (props.position) {
-            case 'top left': return 'top-0 start-0';
+            case 'top left': return '';
             case 'top center': return 'top-0 start-50 translate-middle-x';
             case 'top right': return 'top-0 end-0';
             case 'middle left': return 'top-50 start-0 translate-middle-y';
@@ -91,7 +91,7 @@ const RdsToast = (props: RdsToastProps) => {
                                     className="btn-close btn-primary text-primary"
                                 ></button>
                             </div>
-                            <div className="toast-body">{props.message}</div>
+                            <div className="toast-body text-body">{props.message}</div>
 
 
                             <div className={`toast-footer justify-content-end align-items-end ${props.layout === "download" ? "d-block" : "d-none"}`}>

--- a/raaghu-elements/src/rds-toast/rds-toast.tsx
+++ b/raaghu-elements/src/rds-toast/rds-toast.tsx
@@ -95,7 +95,7 @@ const RdsToast = (props: RdsToastProps) => {
 
 
                             <div className={`toast-footer justify-content-end align-items-end ${props.layout === "download" ? "d-block" : "d-none"}`}>
-                                <div className="d-flex ml-4">
+                                <div className="d-flex text-body ml-4">
                                     <div className="progress w-100 ml-4" aria-valuenow={props.progressWidth} aria-valuemin={0} aria-valuemax={100}>
                                         <div className="progress-bar btn-primary" role="progressbar"
                                             style={{ width: `${props.progressWidth}%`, textAlign: "center" }}
@@ -105,7 +105,7 @@ const RdsToast = (props: RdsToastProps) => {
                                     </div>
                                     <label className="progress-label ml-4">{props.progressWidth}%</label>
                                 </div>
-                                <label className="filename">{props.filename}</label>
+                                <label className="filename text-body">{props.filename}</label>
                                 <div className="d-flex toast-footer justify-content-end pb-1 pe-4">
                                     <button type="button" className="btn text-primary btn-sm">Cancel</button>
                                     <button type="button" className="btn btn-primary btn-sm">Go To Downloads</button>


### PR DESCRIPTION
## Description
> Dark theme icon is not display & alignment issue.
> Refer to wireframe as an alignment issue.


-  **Resolved Elements> Toast > Default > Text alignment issue is fix**



## Screenshots :
![image](https://github.com/user-attachments/assets/56599a0c-fae5-4a35-9ebf-4ab83d04e4c2)

![image](https://github.com/user-attachments/assets/ee572344-1bef-4226-af4f-04e14007dc5e)

![image](https://github.com/user-attachments/assets/74139b6c-94d3-4cc1-8748-ee35f37e19e6)

![image](https://github.com/user-attachments/assets/aa0ee9f6-90df-40fc-a11e-4a8ec9f0fcc7)


 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
