### PR TITLE
Resolved bug 1731 : Design System > Elements > Ratings > Colors of Unrated items is different than WF on Slider.

### DIFF
--- a/raaghu-elements/src/rds-rating/rds-rating.tsx
+++ b/raaghu-elements/src/rds-rating/rds-rating.tsx
@@ -120,7 +120,7 @@ const RdsRating = (props: RdsRatingProps) => {
     props.colorVariant === 'secondary' ? '#2539FF' :
     '#343a40';
 
-  const lighterColor = lightenColor(primaryColor, 25); // Lighten the primary color by 25%
+  const lighterColor = lightenColor(primaryColor, 20); // Lighten the primary color by 20%
 
   const getBackgroundStyle = () => {
     let background = '';


### PR DESCRIPTION
## Description
> Resolve the issues on Element: 
1. Resolved issue on Element Ratings Colors of Unrated items is different than WF on Slider.

## Screenshots :
 
![image](https://github.com/user-attachments/assets/eda5bb35-958f-4fb2-83f9-8024aa3363e1)

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes