### PR TITLE
Bug 1513: Resolved Issue on Element > File uploader >Export icon arrow should display proper and close icon should align properly.

### DIFF
--- a/raaghu-elements/src/rds-file-uploader/rds-file-uploader.css
+++ b/raaghu-elements/src/rds-file-uploader/rds-file-uploader.css
@@ -174,6 +174,6 @@
 .chosenFileSpan {
   width: 25rem;
 }
-.theme-light svg {
+.upload-icon {
  stroke: none !important;
 }

--- a/raaghu-elements/src/rds-file-uploader/rds-file-uploader.css
+++ b/raaghu-elements/src/rds-file-uploader/rds-file-uploader.css
@@ -174,3 +174,6 @@
 .chosenFileSpan {
   width: 25rem;
 }
+.theme-light svg {
+ stroke: none !important;
+}

--- a/raaghu-elements/src/rds-file-uploader/rds-file-uploader.tsx
+++ b/raaghu-elements/src/rds-file-uploader/rds-file-uploader.tsx
@@ -387,7 +387,7 @@ const RdsFileUploader = (props: RdsFileUploaderProps) => {
               key={index}
               className="d-flex justify-content-between p-3 mt-3 fileName border"
             >
-              <div className="d-flex gap-2 align-items-center">
+              <div className="d-flex gap-2 ">
                 <span>
                   {props.showThumbnail && file.type.startsWith("image/") ? (
                     <img
@@ -802,7 +802,7 @@ const RdsFileUploader = (props: RdsFileUploaderProps) => {
                   </a>
                 </span>
               </div>
-              <div className="closeIcon">
+              <div className="closeIcon mt-2">
                 <span className="text-muted opacity-50">
                   {(file.size / 1048576).toFixed(2)} MB
                 </span>
@@ -915,7 +915,7 @@ const RdsFileUploader = (props: RdsFileUploaderProps) => {
         </div>
         <div>
           <form>
-            <div className={`align-items-center d-flex mt-1 flex-row`}>
+            <div className={` d-flex mt-1 flex-row`}>
               <label
                 htmlFor="file1"
                 className={`border-end-0 align-items-center custom-file-button upload-btn ${sizeClass}`}


### PR DESCRIPTION

## Description
> Resolved Issue on Element > File uploader >Export icon arrow should display proper and close icon should align properly.
-  ** File Uploader**

> Make the changes to /rds-file-uploader.tsx file.

## Screenshots :
 
![image](https://github.com/user-attachments/assets/7e30f4a1-f4cd-4603-bd31-b8cb629269b9)

![image](https://github.com/user-attachments/assets/f0b0fab2-cdc9-4e3e-ab7f-e9c479006f38)

![image](https://github.com/user-attachments/assets/df836232-11d7-4254-856f-1bcb6dce1f09)

![image](https://github.com/user-attachments/assets/fdc21336-e25f-41a3-b5b9-8d097a1db113)

![image](https://github.com/user-attachments/assets/10d8c7c9-f31c-4fec-ad80-6474309c1fc9)

![image](https://github.com/user-attachments/assets/a9a4e000-91cb-41a9-94af-6f873715b351)

![image](https://github.com/user-attachments/assets/a9a4e000-91cb-41a9-94af-6f873715b351)

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes