### PR TITLE
Resolved Bug 1720 - Grid Line Not Visible In Dark Theme

### DIFF
--- a/raaghu-elements/src/rds-chart-polar-area/rds-chart-polar-area.css
+++ b/raaghu-elements/src/rds-chart-polar-area/rds-chart-polar-area.css
@@ -1,0 +1,3 @@
+.theme-dark #Polar_Area_chart {
+    background-color: rgb(51 51 51)
+}

--- a/raaghu-elements/src/rds-chart-polar-area/rds-chart-polar-area.stories.tsx
+++ b/raaghu-elements/src/rds-chart-polar-area/rds-chart-polar-area.stories.tsx
@@ -18,7 +18,7 @@ type Story = StoryObj<typeof RdsPolarAreaChart>;
 
 export const PolarAreaChart: Story = {
     args: {
-        id: "Polar Area chart",
+        id: "Polar_Area_chart",
         radius: 300,
         dataSets: [
             {

--- a/raaghu-elements/src/rds-chart-scatter/rds-chart-scatter.css
+++ b/raaghu-elements/src/rds-chart-scatter/rds-chart-scatter.css
@@ -1,5 +1,8 @@
 
-.theme-dark #Scatter_Chart , #Scatter_Chart_Multi_Axis{
+.theme-dark #Scatter_Chart {
     background-color: rgb(51 51 51)
 }
 
+.theme-dark #Scatter_Chart_Multi_Axis{
+    background-color: rgb(51 51 51)
+}


### PR DESCRIPTION
## Description
> Resolve the issues on Element : 
-  **Polar Area Chart**
-  **Scatter Chart**

## Screenshots :
1.Scatter Chart With Multi Axis In Dark Theme
![image](https://github.com/user-attachments/assets/75218ad6-6845-48d3-98a6-d83d0f4415d6)

2.Scatter Chart With Multi Axis In Light Theme
![image](https://github.com/user-attachments/assets/151818c3-a756-4df6-8e6e-074c91cad0b5)

3.Polar Area Chart In Dark Theme
![image](https://github.com/user-attachments/assets/3549b319-6d23-4a87-965e-0a055f2f189d)

 
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes