### PR TITLE
Resolved Bug 2032 : Design System > Element > Select List > after selecting 2nd select list loader is still displayed for the 1st select list on page.

### DIFF
--- a/raaghu-elements/src/rds-select-list/rds-select-list.tsx
+++ b/raaghu-elements/src/rds-select-list/rds-select-list.tsx
@@ -295,6 +295,10 @@ const RdsSelectList = (props: RdsSelectProps) => {
   };
 
   const handleInputChange = (inputValue: string) => {
+    if (inputValue === "") {
+    // Do not show loader when closing the dropdown
+    return;
+    }
     setIsSearching(true);
     if (searchTimer) {
       clearTimeout(searchTimer);


### PR DESCRIPTION
## Description
> Resolve the issues on Element: 
1. Resolved issue on Element - Select List - after selecting 2nd select list loader is still displayed for the 1st select list on page.

## Screenshots :
 
![image](https://github.com/user-attachments/assets/a159f79a-ea4b-4235-888a-f25e3621b7e1)

https://github.com/user-attachments/assets/3602f26a-98a1-478e-864e-b3ec4a1bc01e


 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
