### PR TITLE
Resolved Bug 2182: Design System > Icon Label and Label > Stories can be clubbed instead of keeping 2 different components

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -68,7 +68,8 @@
     #components-user-management,  
     #components-user-permission,  
     #components-user-roles,  
-    #components-user-table
+    #components-user-table,
+    #components-label
     {
         display: none;
     }
@@ -138,7 +139,8 @@
     [data-item-id="components-user-management"],  
     [data-item-id="components-user-permission"], 
     [data-item-id="components-user-roles"], 
-    [data-item-id="components-user-table"] {
+    [data-item-id="components-user-table"],
+    [data-item-id="components-label"] {
       display: none !important;
     }
     [data-id="components-api-scope-resource"],
@@ -207,7 +209,8 @@
     [data-id="components-user-management"], 
     [data-id="components-user-permission"],
     [data-id="components-user-roles"],
-    [data-id="components-user-table"]  {
+    [data-id="components-user-table"],
+    [data-id="components-label"] {
       display: none !important;
     }
 </style>

--- a/raaghu-elements/src/rds-icon-label/rds-icon-label.css
+++ b/raaghu-elements/src/rds-icon-label/rds-icon-label.css
@@ -25,3 +25,22 @@
   height: 25px !important;
   width: 25px !important;
 }
+
+/* Label styles merged from rds-label */
+.singleLine {
+  white-space: nowrap;
+  overflow: hidden;
+}
+.multiline{
+  word-break: break-all;
+}
+.bold {
+  font-weight: bold;
+}
+.italic {
+  font-style: italic;
+}
+
+.poppins {
+  font-family: Poppins;
+}

--- a/raaghu-elements/src/rds-icon-label/rds-icon-label.stories.tsx
+++ b/raaghu-elements/src/rds-icon-label/rds-icon-label.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta = {
     layout: 'padded',
     docs:{
       description: {
-  component: `The **Icon Label** component displays a text label combined with an icon, allowing for clear and visually appealing UI elements. It supports various \`colorVariant\` options to match different themes and provides three \`size\` options ("small", "medium", "large") to adjust the icon and label dimensions accordingly. Additionally, the component offers flexible icon positioning, enabling the icon to appear either on the left or right side of the label. This makes it perfect for use in buttons, tags, badges, or any interface element that requires an icon paired with descriptive text for enhanced usability and aesthetics.`
+  component: `The **Icon Label** component displays a text label with or without an icon, allowing for clear and visually appealing UI elements. It supports various \`colorVariant\` options to match different themes and provides three \`size\` options ("small", "medium", "large") to adjust the icon and label dimensions accordingly. Additionally, the component offers flexible icon positioning, enabling the icon to appear either on the left or right side of the label. It also supports all label features like \`fontWeight\` options, \`italic\` styling, and \`required\` flag. This makes it perfect for use in buttons, tags, badges, form labels, or any interface element that requires an icon paired with descriptive text for enhanced usability and aesthetics.`
 }
 
     }
@@ -33,6 +33,20 @@ const meta: Meta = {
       options: ['small', 'medium', 'large'],
       control: { type: 'radio' }
     },
+    fontWeight: {
+      options: [
+        "black",
+        "bold",
+        "bolder",
+        "extrabold",
+        "light",
+        "lighter",
+        "medium",
+        "normal",
+        "semibold",
+      ],
+      control: { type: "select" },
+    }
   },
 } satisfies Meta<typeof RdsIconLabel>;
 
@@ -45,6 +59,7 @@ export const Default: Story = {
     icon: "users",
     size: "medium",
     colorVariant: "primary",
+    withIcon: true,
   }
 } satisfies Story;
 Default.parameters = { controls: { include: ['label', 'icon', 'colorVariant', 'size'] } };
@@ -56,6 +71,7 @@ export const WithPosition: Story = {
     size: "medium",
     iconposition: "left",
     colorVariant: "primary",
+    withIcon: true,
   },
   argTypes: {
     iconposition: {
@@ -68,4 +84,15 @@ export const WithPosition: Story = {
   }
 } satisfies Story;
 WithPosition.parameters = { controls: { include: ['label', 'icon', 'colorVariant', 'size', 'iconposition'] } };
+
+export const CustomLabel: Story = {
+  args: {
+    label: "Label",
+    fontWeight: "bold",
+    italic: false,
+    required: false,
+    custom: true,
+  }
+} satisfies Story;
+CustomLabel.parameters = { controls: { include: ['label', 'fontWeight', 'italic', 'required'] } };
 

--- a/raaghu-elements/src/rds-icon-label/rds-icon-label.tsx
+++ b/raaghu-elements/src/rds-icon-label/rds-icon-label.tsx
@@ -1,18 +1,32 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import "./rds-icon-label.css";
 import RdsIcon from "../rds-icon/rds-icon";
 import RdsLabel from "../rds-label/rds-label";
+import { fontWeight } from "../../libs";
 
 export interface RdsIconLabelProps {
+    children?: ReactNode;
     label?: string;
     icon?: string;
     size: string;
     fill?: boolean;
     iconposition?: string;
     colorVariant?: string;
+    multiline?: boolean;
+    class?: string;
+    italic?: boolean;
+    fontWeight?: fontWeight;
+    required?: boolean;
+    id?: any;
+    onClick?: React.MouseEventHandler<HTMLElement>;
+    withIcon?: boolean;
+    custom?: boolean;
 }
 
 const RdsIconLabel = (props: RdsIconLabelProps) => {
+    const isItalic = props.italic ? ' fst-italic' : ''
+    const fontWeightClass = props.fontWeight ? "fw-" + props.fontWeight : ""
+
     const classes = () => {
         let classes: string = 'd-flex';
         if (props.size) {
@@ -36,6 +50,8 @@ const RdsIconLabel = (props: RdsIconLabelProps) => {
 
     return (
         <>
+    {
+    props.withIcon && (
             <div className={inputClass()}>
                 <RdsIcon
                     classes={classes()}
@@ -47,6 +63,19 @@ const RdsIconLabel = (props: RdsIconLabelProps) => {
                 />
                 <RdsLabel label={props.label} size={classes()} class={"align-items-center " + classes()} />
             </div>
+        )
+    }
+    {
+        props.custom && (
+            <p className={`d-flex p-0 m-0 ${props.multiline ? ' text-break' : ' singleLine'} ${props.class ? props.class : ""}`}>
+                <label className={`form-label mb-0 ${fontWeightClass} ${isItalic}`} htmlFor={props?.id}
+                    onClick={props.onClick}>{props.label}</label>
+                {props.required && (
+                    <span className="text-danger ms-1">*</span>
+                )}
+        </p>
+        )
+    }
         </>
     );
 };


### PR DESCRIPTION
## Description
> Resolve the issues on Components Icon Label and Label are clubbed

-  **Icon Label and Label**
> Make the changes to stories, css and tsx file.

## Screenshots:
1.Label inside to Icon Label:
![image](https://github.com/user-attachments/assets/c44ffc2b-8cf2-4767-bce6-8c1e49e80a0f)

 
## Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes
 