### PR TITLE
Resolved Bug 2212: Design System > Elements > Grid > Default > 3 dots not displayed properly

### DIFF
--- a/raaghu-components/src/rds-comp-grid/rds-comp-grid.css
+++ b/raaghu-components/src/rds-comp-grid/rds-comp-grid.css
@@ -149,3 +149,7 @@ svg.text-dark {
 .resizable-table th.resizing {
   user-select: none;
 }
+/* Target the three dots icon inside RdsDropdown */
+#sortTable tbody td.text-center.align-middle svg {
+  overflow: visible !important;
+}


### PR DESCRIPTION
## Description

> Resolve the issues on Element Grid for 3 dots not displayed properly
-  **3 dropdown dots**
> Make the changes to css file.

## Screenshots:

1.Deafult:
![image](https://github.com/user-attachments/assets/169edb54-3ce1-446f-aaef-0e7bb2aafbc3)

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes