### PR TITLE
Resolved Bug 2209: Design System > Element > Tag > Multi Tag Input > Close icon is larger than required

### DIFF
--- a/raaghu-elements/src/rds-tag/rds-tag.tsx
+++ b/raaghu-elements/src/rds-tag/rds-tag.tsx
@@ -106,8 +106,8 @@ const RdsTag = (props: RdsTagProps) => {
                                                                 name="cancel"
                                                                 fill={false}
                                                                 stroke={true}
-                                                                width="15"
-                                                                height="15"
+                                                                width="12"
+                                                                height="12"
                                                                 borderRadius={
                                                                     closeFill == true
                                                                         ? "50%"


### PR DESCRIPTION
## Description
> Resolve the issues on Element Tag for Close icon is larger than required

-  **Multi Tag Input**
> Make the changes to tsx file.

## Screenshots:
1.Multi Tag Input:
![image](https://github.com/user-attachments/assets/5990ca14-3749-4a17-8e8e-64dd5c7f6b90)
 
## Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes
 