### PR TITLE
Resolved Bug 2216: Design System > Docs > For all elements and components > Extra space is displayed at the top of the page

### DIFF
--- a/raaghu-react-themes/src/styles/default.scss
+++ b/raaghu-react-themes/src/styles/default.scss
@@ -364,6 +364,10 @@ html[theme="dark"] {
     border-color: $input-bg-border;
   }
 }
+/* Docs Spacing */
+.css-k7lbue {
+  padding: 3rem 1rem !important;
+}
 
 @import "./custom.scss";
 @import "../../node_modules/bootstrap/scss/bootstrap.scss";


### PR DESCRIPTION
## Description
> Resolve the issues on All Elements and Components for showing Extra space is displayed at the top of the page.

> Make the changes to default.scss file.

## Screenshots:
1.Now:
![image](https://github.com/user-attachments/assets/4a91529a-a6ab-4bfc-b8be-2db264269c4f)

2.Before:
![image](https://github.com/user-attachments/assets/0059bb8f-133e-4ffa-8ec0-a503f700e5ef)
 
## Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes
 