### PR TITLE
Resolved Bug 2235: Design System > Elements > Offcanvas > The size of hover effect of close icon is not correct and missing hover effect in light theme

### DIFF
--- a/raaghu-elements/src/rds-offcanvas/rds-offcanvas.css
+++ b/raaghu-elements/src/rds-offcanvas/rds-offcanvas.css
@@ -19,11 +19,11 @@
   border-radius: 5px;
 }
 
-.offcanvas .offcanvas-header .close:hover {
+/* .offcanvas .offcanvas-header .close:hover {
   background: aliceblue;
   border-radius: 5px;
   transition: all 0.2s ease-in-out;
-}
+} */
 
  .theme-dark .offcanvas-text .btn.btn-transparent-primary,
  .theme-dark .offcanvas-text .btn.btn-outline-primary {
@@ -34,4 +34,10 @@
 
 .theme-dark .offcanvas-text .btn {
   color: #ffffff !important;
+}
+
+#close-btn button.btn.btn-undefined.position-relative.align-items-center.btn-lg.d-flex.btn-icon.justify-content-center.gap-2:hover{
+background: aliceblue;
+  border-radius: 5px;
+  transition: all 0.2s ease-in-out;
 }

--- a/raaghu-elements/src/rds-offcanvas/rds-offcanvas.tsx
+++ b/raaghu-elements/src/rds-offcanvas/rds-offcanvas.tsx
@@ -100,7 +100,7 @@ const RdsOffcanvas = (props: RdsOffcanvasProps) => {
               {props.canvasTitle}
             </h5>
           )}
-          <span className="close">
+          <span className="close" id="close-btn">
             <RdsButton
               icon="cross"
               size="large"


### PR DESCRIPTION
## Description
> Resolve the issues on Element Offcanvas hover effect is not showing properly.

## Screenshots :
 
![image](https://github.com/user-attachments/assets/159fee17-26f2-48b8-b6e3-6e82bf9372a9)

![image](https://github.com/user-attachments/assets/f6a053e6-46bd-4448-9ee1-eb128fcc57d6)

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes