### PR TITLE
Resolved Bug 2239: Design System > Component > Button Group > in dark mode checkbox, icon, and radio button groups are only visible on hover

### DIFF
--- a/raaghu-elements/src/rds-button-group/rds-button-group.css
+++ b/raaghu-elements/src/rds-button-group/rds-button-group.css
@@ -1,3 +1,11 @@
+/* Button Group Light Mode Styles */
 .hover-button :hover {
     background: #7825e9;
 }
+/* Dark Mode - Only used button variants */
+.theme-dark .rds-button-group .btn-outline-primary,
+.theme-dark .rds-button-group .btn-outline-light {
+    color: #ffffff !important;
+}
+/* Icons */
+.theme-dark .rds-button-group svg { fill: currentColor !important; }

--- a/raaghu-elements/src/rds-button-group/rds-button-group.tsx
+++ b/raaghu-elements/src/rds-button-group/rds-button-group.tsx
@@ -36,7 +36,7 @@ const RdsButtonGroup = (props: RdsButtonGroupProps) => {
  
  
     return (
-        <>
+        <div className="rds-button-group">
             {props.role != Role.Button && (
                 <div
                     className={`${props.vertical == true ? "btn-group-vertical" : "btn-group member-count"
@@ -108,7 +108,7 @@ const RdsButtonGroup = (props: RdsButtonGroupProps) => {
  
  
  
-        </>
+        </div>
     );
 };
  


### PR DESCRIPTION
## Description

> Resolve the issues on Element Button Group for in dark mode checkbox, icon, and radio button groups are only visible on hover

> Make the changes to css file.

## Screenshots:
1. Checkbox Button Group:
![image](https://github.com/user-attachments/assets/02491b3a-4b82-446c-8d5f-39178e31b323)

2. Icon Button Group:
![image](https://github.com/user-attachments/assets/e67f8dd6-9bcf-4bf4-a075-6bb6e40f0c5c)

3. Radio Button Group:
![image](https://github.com/user-attachments/assets/39e9921f-51ba-440d-847f-aec717989f7e)
 
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes