### PR TITLE
Resolved Bug 2250: Design System > In the Bank Card Details component, 'Set as Default' and 'Edit' options are not vertically aligned with the title

### DIFF
--- a/raaghu-elements/src/rds-bank-card-detail/rds-bank-card-detail.css
+++ b/raaghu-elements/src/rds-bank-card-detail/rds-bank-card-detail.css
@@ -16,3 +16,7 @@
 #flexRadioD:checked {
     border-radius: 50% !important;
 }
+
+.bank-card-detail-align {
+    margin-left: 1rem !important;
+}

--- a/raaghu-elements/src/rds-bank-card-detail/rds-bank-card-detail.tsx
+++ b/raaghu-elements/src/rds-bank-card-detail/rds-bank-card-detail.tsx
@@ -91,21 +91,21 @@ const RdsBankCardDetail = (props: RdsBankCardDetailProps) => {
                                     <div className="mt-2 ms-4">
                                         {activeButton == index ? (clicked == false ? (
                                             <a
-                                                className="ms-3 text-primary text-decoration-none"
+                                                className="bank-card-detail-align text-primary text-decoration-none"
                                                 onClick={setDefaultHandler}
                                             >
                                                 Set as default
                                             </a>
                                         ) : (
                                             <a
-                                                className="ms-3 text-muted me-1 text-decoration-none"
+                                                className="bank-card-detail-align text-muted me-1 text-decoration-none"
                                                 onClick={setDefaultHandler}
                                             >
                                                 Default
                                             </a>
                                         )) : (
                                             <a
-                                                className="ms-3 text-primary text-decoration-none"
+                                                className="bank-card-detail-align text-primary text-decoration-none"
                                             >
                                                 Set as default
                                             </a>


### PR DESCRIPTION
## Description
> Resolve the issues on Component Bank Card Details for not vertically aligned with the title

-  **Default**
> Make the changes to css and tsx file.


## Screenshots:
1. Bank Card Details Manager:
![image](https://github.com/user-attachments/assets/dc73aa42-2b0d-4126-9895-a4495416baac)

 
## Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes
 