### PR TITLE
Resolved Bug 2254: Design System > Component > Scrollspy the button labelled 'Third' is overlapping with the card information below and is not properly aligned

### DIFF
--- a/raaghu-elements/src/rds-scrollspy/rds-scrollspy.css
+++ b/raaghu-elements/src/rds-scrollspy/rds-scrollspy.css
@@ -49,12 +49,17 @@
     flex-wrap: nowrap;
     justify-content: flex-start;
     overflow-x: auto;
+    gap: 5px;
+    padding: 0;
   }
 
   .navButton {
     min-width: 80px;
     height: 32px;
     font-size: 12px;
+    margin-right: 0 !important;
+    margin-bottom: 0 !important;
+    flex-shrink: 0;
   }
 
   .scrossSpyItem {
@@ -128,4 +133,22 @@
 }
 #scrollspy p{
  color: black !important;
+}
+
+/* Dark mode styles for scrollspy component - using specific container selector */
+.theme-dark .container #scrollspy ~ div .scrossSpyItem {
+  background: #232933 !important;
+  color: #dee2e6 !important;
+}
+
+.theme-dark .container #scrollspy ~ div .contentHeader {
+  color: #fcfcfc !important;
+}
+
+.theme-dark .container #scrollspy ~ div .contentParagraph {
+  color: #A8A8A8 !important;
+}
+
+.theme-dark .container #scrollspy ~ div .scrossSpyItem p {
+  color: #A8A8A8 !important;
 }


### PR DESCRIPTION
## Description
> Resolve the issues on Component Scrollspy the button labelled 'Third' is overlapping with the card information below.
> Resolve the issue in dark mode for not see contents properly in dark mode.

-  **Default**
- **Dark Mode**
> Make the changes to css file.

## Screenshots:

1. Default (Small Mobile):
![image](https://github.com/user-attachments/assets/da575c64-03c5-497e-9e24-b0bfc9254a49)

2.Default (Dark Mode):
![image](https://github.com/user-attachments/assets/016a9bbf-49af-4286-9789-53a9e638346d)
 
 
## Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes
 