### PR TITLE
Resolved Bug 2255 : Design System > Stat component, the Default section content is not styled for dark mode

### DIFF
--- a/raaghu-elements/src/rds-stat/rds-stat.css
+++ b/raaghu-elements/src/rds-stat/rds-stat.css
@@ -3,6 +3,10 @@
   transition-timing-function: ease-in-out !important;
 }
 
+/* Dark mode styles for default stat component */
+.theme-dark .card-body[data-testId="rds-stat"] {
+  background-color: #232933 !important;
+}
 
 .app-shell-layout {
   height: 77vh;


### PR DESCRIPTION
## Description
> Resolve the issues on Element Stat for, the Default section content is not styled for dark mode

-  **Default**

> Make the changes to css file.

## Screenshots:
1. Default (Dark Mode):
![image](https://github.com/user-attachments/assets/026ec9e0-ec64-43af-b0cd-16f249c61461)
 
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes