### PR TITLE
Resolved Bug 2266: Design System > Component > Widget > Dark mode is not properly applied for stories like 'With Line Chart', 'With Doughnut Chart', and 'With Bar Chart'

### DIFF
--- a/raaghu-elements/src/rds-widget/rds-widget.css
+++ b/raaghu-elements/src/rds-widget/rds-widget.css
@@ -1,2 +1,29 @@
+/* Shared styles for specific charts in dark theme */
+.theme-dark .card[data-component="rds-widget"]:has(#linechart),
+.theme-dark .card[data-component="rds-widget"]:has(#doughnutchart),
+.theme-dark .card[data-component="rds-widget"]:has(#barchart),
+.theme-dark .card[data-component="rds-widget"]:has(#linechart) .card-body,
+.theme-dark .card[data-component="rds-widget"]:has(#linechart) .card-header,
+.theme-dark .card[data-component="rds-widget"]:has(#doughnutchart) .card-body,
+.theme-dark .card[data-component="rds-widget"]:has(#doughnutchart) .card-header,
+.theme-dark .card[data-component="rds-widget"]:has(#barchart) .card-body,
+.theme-dark .card[data-component="rds-widget"]:has(#barchart) .card-header {
+  background-color: #232933 !important;
+  border-color: #343a40 !important;
+  color: #dee2e6 !important;
+}
 
+.theme-dark .card[data-component="rds-widget"] .border-danger-50 {
+  background-color: #2b3138 !important;
+  border-color: #495057 !important;
+  color: #dee2e6 !important;
+}
 
+.theme-dark .card[data-component="rds-widget"] .border-danger-50 .fw-bold,
+.theme-dark .card[data-component="rds-widget"] .border-danger-50 .text-secondary.fw-medium {
+  color: #dee2e6 !important;
+}
+
+.theme-dark .card[data-component="rds-widget"] p.text-secondary {
+  color: #0d6efd !important;
+}

--- a/raaghu-elements/src/rds-widget/rds-widget.tsx
+++ b/raaghu-elements/src/rds-widget/rds-widget.tsx
@@ -5,6 +5,7 @@ import RdsButtonGroup, { Role } from "../rds-button-group/rds-button-group";
 import RdsBigNumber from "../rds-big-number/rds-big-number";
 import RdsProgressBar from "../rds-progress-bar";
 import RdsButton from "../rds-button";
+import "./rds-widget.css";
 
 export interface RdsWidgetProps {
   isRefreshRequired?: boolean;
@@ -86,6 +87,7 @@ const RdsWidget = (props: RdsWidgetProps) => {
           `card ${props.isCardStretch ? "card-stretch gutter-b" : ""} ` +
           classes()
         }
+        data-component="rds-widget"
         style={{
           height: `${props.height}`,
           minHeight: `${props.minHeight}`,


### PR DESCRIPTION
## Description
> Resolve the issues on Component Widget for Dark mode is not properly applied for all stories

 **Dark Mode**

> Make the changes to css and tsx file.

## Screenshots:
1. With Line Chart:
![image](https://github.com/user-attachments/assets/7055fd90-63fd-488d-bf67-ddddc23370e6)

2. With Doughnut Chart:
![image](https://github.com/user-attachments/assets/b2bcba23-e4d0-4832-9736-fe9d49104a40)

3. With Bar Chart:
![image](https://github.com/user-attachments/assets/c37e9da9-e9c4-4b5f-b8b6-b3c209813e6a)

4. Portal:
![image](https://github.com/user-attachments/assets/2d34d13c-fffb-467f-ac46-54afcc581a89)
 
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes