### PR TITLE
Resolved Bug 2266: Design System > Component > Widget > Dark mode is not properly applied for stories like 'With Line Chart', 'With Doughnut Chart', and 'With Bar Chart' 

### DIFF
--- a/raaghu-components/src/rds-comp-widget/rds-comp-widget.tsx
+++ b/raaghu-components/src/rds-comp-widget/rds-comp-widget.tsx
@@ -87,6 +87,7 @@ const RdsWidget = (props: RdsCompWidgetProps) => {
           `card ${props.isCardStretch ? "card-stretch gutter-b" : ""} ` +
           classes()
         }
+        data-component="rds-widget"
         style={{
           height: `${props.height}`,
           minHeight: `${props.minHeight}`,

--- a/raaghu-react-themes/src/styles/colorvariables-dark.scss
+++ b/raaghu-react-themes/src/styles/colorvariables-dark.scss
@@ -3710,3 +3710,33 @@ label{
 .accordion-selected .accordion-button {
     background-color: $neutral-400; /* Change this to your desired selected color */
 }
+
+/* Dark mode styles for widget components */
+.card[data-component="rds-widget"]:has(#linechart),
+.card[data-component="rds-widget"]:has(#doughnutchart),
+.card[data-component="rds-widget"]:has(#barchart),
+.card[data-component="rds-widget"]:has(#linechart) .card-body,
+.card[data-component="rds-widget"]:has(#linechart) .card-header,
+.card[data-component="rds-widget"]:has(#doughnutchart) .card-body,
+.card[data-component="rds-widget"]:has(#doughnutchart) .card-header,
+.card[data-component="rds-widget"]:has(#barchart) .card-body,
+.card[data-component="rds-widget"]:has(#barchart) .card-header {
+    background-color: #232933 !important;
+    border-color: #343a40 !important;
+    color: #dee2e6 !important;
+}
+
+.card[data-component="rds-widget"] .border-danger-50 {
+    background-color: #2b3138 !important;
+    border-color: #495057 !important;
+    color: #dee2e6 !important;
+}
+
+.card[data-component="rds-widget"] .border-danger-50 .fw-bold,
+.card[data-component="rds-widget"] .border-danger-50 .text-secondary.fw-medium {
+    color: #dee2e6 !important;
+}
+
+.card[data-component="rds-widget"] p.text-secondary {
+    color: #0d6efd !important;
+}


### PR DESCRIPTION
## Description

> Resolve the issues on Component Widget for Dark mode is not properly applied for all stories

-  **Dark Mode**

> Make the changes to tsx and scss file.

## Screenshots:
1. With Line Chart:
![image](https://github.com/user-attachments/assets/baa44e8d-a280-4ddc-87dd-f033211c578c)

2. With Doughnut Chart:
![image](https://github.com/user-attachments/assets/f83081c7-64d7-4ea8-ac36-bf15bc61bdc8)

3. With Bar Chart:
![image](https://github.com/user-attachments/assets/36373d05-f44f-4b19-b7c8-ec6c1623cb7e)
 
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes