### PR TITLE
Resolved Bug 2250: Design System > Component > Bank Card Details > The 'Set as Default' and 'Edit' options are not vertically aligned with the title

### DIFF
--- a/raaghu-components/src/rds-comp-bank-card-detail/rds-comp-bank-card-detail.css
+++ b/raaghu-components/src/rds-comp-bank-card-detail/rds-comp-bank-card-detail.css
@@ -16,7 +16,9 @@
 #flexRadioD:checked {
     border-radius: 50% !important;
 }
-
-.bank-card-detail-align {
-    margin-left: 1rem !important;
+/* Align "Set as default" links to the left for vertical alignment */
+#set-as-default-link {
+    margin-left: 1.1rem !important;
+    position: relative !important;
+    display: inline-block !important;
 }

--- a/raaghu-components/src/rds-comp-bank-card-detail/rds-comp-bank-card-detail.tsx
+++ b/raaghu-components/src/rds-comp-bank-card-detail/rds-comp-bank-card-detail.tsx
@@ -91,21 +91,24 @@ const RdsCompBankCardDetail = (props: RdsCompBankCardDetailProps) => {
                                     <div className="mt-2 ms-4">
                                         {activeButton == index ? (clicked == false ? (
                                             <a
-                                                className="bank-card-detail-align text-primary text-decoration-none"
+                                                id="set-as-default-link"
+                                                className="text-primary text-decoration-none"
                                                 onClick={setDefaultHandler}
                                             >
                                                 Set as default
                                             </a>
                                         ) : (
-                                            <a
-                                                className="bank-card-detail-align text-muted me-1 text-decoration-none"
+                                                <a
+                                                id="set-as-default-link"
+                                                className="text-muted me-1 text-decoration-none"
                                                 onClick={setDefaultHandler}
                                             >
                                                 Default
                                             </a>
                                         )) : (
                                             <a
-                                                className="bank-card-detail-align text-primary text-decoration-none"
+                                                id="set-as-default-link"
+                                                className="text-primary text-decoration-none"
                                             >
                                                 Set as default
                                             </a>


### PR DESCRIPTION
## Description
> Resolve the issues on Component Bank Card Details for options are not vertically aligned with the title

-  **Set as Default**
- **Default**

> Make the changes to css and tsx file.

## Screenshots:
1. Standard:
![image](https://github.com/user-attachments/assets/b7dfc16c-78ce-4c0e-9998-1cac60ff9631)
 
 
## Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes
 