### PR TITLE
Resolved Bug 2266: Design System > Component > Widget > Dark mode is not properly applied for stories like 'With Line Chart', 'With Doughnut Chart', and 'With Bar Chart'

### DIFF
--- a/raaghu-react-themes/src/styles/colorvariables-dark.scss
+++ b/raaghu-react-themes/src/styles/colorvariables-dark.scss
@@ -3721,7 +3721,7 @@ label{
 .card[data-component="rds-widget"]:has(#doughnutchart) .card-header,
 .card[data-component="rds-widget"]:has(#barchart) .card-body,
 .card[data-component="rds-widget"]:has(#barchart) .card-header {
-    background-color: #232933 !important;
+    background-color: $dark-900 !important;
     border-color: #343a40 !important;
     color: #dee2e6 !important;
 }


### PR DESCRIPTION
## Description
> Resolve the issues on Component Radio Widget Dark mode is not properly applied for stories

-  **Dark Mode**
> Make the changes to scss file.

## Screenshots:
1. With Bar Chart:
<img width="1917" height="989" alt="image" src="https://github.com/user-attachments/assets/c7747715-6f15-4507-b61f-48d6963ae840" />

 
## Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes
 