### PR TITLE
Resolved Bug 2255: Design System > Component > Stat >Default > Content is not styled for dark mode

### DIFF
--- a/raaghu-components/src/rds-comp-stat/rds-comp-stat.css
+++ b/raaghu-components/src/rds-comp-stat/rds-comp-stat.css
@@ -18,6 +18,13 @@
   border-width: 30px !important;
   width: 285px !important;
 }
+
+/* Large mobile view centering */
+@media (max-width: 576px) {
+  .advancestat{
+    margin: 0 auto !important;
+  }
+}
 div.grow {
   transition: all 0.2s ease-in-out;
   transform: translate(0px, 0px);


### PR DESCRIPTION
## Description
> Resolve the issues on Component Stat Default Content is not Align for center in large mobile

-  **Advance**
> Make the changes to css file.

## Screenshots:
1. Advance (Large View):
<img width="1916" height="975" alt="image" src="https://github.com/user-attachments/assets/b5bb520b-a42b-48c2-a26e-12c8ea524e78" />
 

## Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes
 