### PR TITLE
Resolved Bug 2059 : Dark Theme Issue in Docs & Calendar Text Issue

### DIFF
--- a/raaghu-react-themes/src/styles/colorvariables-dark.scss
+++ b/raaghu-react-themes/src/styles/colorvariables-dark.scss
@@ -3803,3 +3803,11 @@ label{
   .style-5 .off, .style-6 .off {
       color: #6c757d;
   }
+
+.rbc-button-link {
+    font-weight: bold;
+}
+
+.css-1cvjpgl {
+    background-color: $black !important;
+}


### PR DESCRIPTION
## Description
> Resolve dark theme issue in docs.
> Resolve Calendar text header issue in dark theme.

## Screenshots :
 
<img width="1882" height="945" alt="image" src="https://github.com/user-attachments/assets/5371534e-9edc-461e-92a4-7526cece9d49" />

<img width="1905" height="943" alt="image" src="https://github.com/user-attachments/assets/47d01a28-87bd-4c90-b8a3-c212d69aacb4" />

<img width="1897" height="762" alt="image" src="https://github.com/user-attachments/assets/417ed0aa-c39e-4e03-90c7-2fb8b3d7c025" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes