### PR TITLE
Resolved Bug 2346: Design System > Header > Selected theme name is not displayed like the selected view name

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -33,11 +33,11 @@ const preview: Preview = {
       toolbar: {
         icon: 'photo',
         items: [
-          { value: 'light', title: 'light' },
-          { value: 'dark', title: 'dark' },
+          { value: 'light', title: 'Light' },
+          { value: 'dark', title: 'Dark' },
         ],
          showName: true,
-        // dynamicTitle: true, // Use dynamic titles for buttons
+        dynamicTitle: true, // Use dynamic titles for buttons
       },
     },
   },


### PR DESCRIPTION
## Description
> Resolve the issues on storybook for not displaying name light or dark mode

-  **Light & Dark**

> Make the changes to preview.tsx file.

## Screenshots:

1. Light Mode (Name): 
<img width="1914" height="700" alt="image" src="https://github.com/user-attachments/assets/680c5493-f7c7-4f61-baa2-a0a9d4ccd86e" />
2. Dark Mode (Name):
<img width="1920" height="691" alt="image" src="https://github.com/user-attachments/assets/535e85e7-63e9-49af-8b83-c62d4f9dba77" />
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes