### PR TITLE
Resolved Bug 2567 and 2580 and 2581 : Design System > Gradient Text with Icon > What to do for icon removal do we have flexibility to replace or remove and Design System > Reviews >Style 7 overlap in docs and Design System > Spinner > Can we set default value as default so that loader will looks bigger than text and which is good as per UI.

### DIFF
--- a/raaghu-components/rds-comp-ai-gradient-text-with-icon/rds-comp-ai-gradient-text-with-icon.stories.tsx
+++ b/raaghu-components/rds-comp-ai-gradient-text-with-icon/rds-comp-ai-gradient-text-with-icon.stories.tsx
@@ -24,5 +24,7 @@ export const Default: Story = {
         logoUrl: "https://raaghustorageaccount.blob.core.windows.net/raaghu-blob/pundit-color-logo.png",
         logo: <AutoAwesomeIcon className="pundit-icon" />,
         title: "AI Pundit is creating some magic for you",
+        showImage: true,
+        showIcon: true,
     },
 }

--- a/raaghu-components/rds-comp-ai-gradient-text-with-icon/rds-comp-ai-gradient-text-with-icon.tsx
+++ b/raaghu-components/rds-comp-ai-gradient-text-with-icon/rds-comp-ai-gradient-text-with-icon.tsx
@@ -5,13 +5,18 @@ export interface RdsCompAiGradientTextProps {
   logoUrl?: string;
   title?: string;
   logo?: React.ReactNode;
+  showImage?: boolean;
+  showIcon?: boolean;
 }
 
 const RdsCompAiGradientTextWithIcon = (props: RdsCompAiGradientTextProps) => {
   return (
     <div className="rds-gradient-text-with-icon">
-      <img src={props.logoUrl} alt="Logo" className="rds-gradient-text-with-icon__logo" />
-      {props.logo}
+      {props.showImage && (
+        <img src={props.logoUrl} className="rds-gradient-text-with-icon__logo" />
+      )}
+
+      {props.showIcon && props.logo}
       <h6 className="rds-gradient-text-with-icon__title">{props.title}</h6>
     </div>
   );

--- a/raaghu-components/rds-comp-reviews/rds-comp-reviews.tsx
+++ b/raaghu-components/rds-comp-reviews/rds-comp-reviews.tsx
@@ -52,9 +52,19 @@ const RdsCompReviews = (props: RdsCompReviewsProps) => {
   return (
     <Box className="rds-comp-reviews">
       {props.variantType === VariantType.Default && (
-        <Grid container spacing={2}>
+        <Grid container spacing={2} wrap="wrap">
           {props.itemList.map((item: Item, index: number) => (
-            <Grid component="div" key={index} size={{ xs: 12, sm: 6, md: 4 }}>
+            <Grid 
+             key={index}
+             size={{
+               xs: 12,
+               sm: 12,
+               md: 4,
+               lg: 6,
+               xl: 6
+             }}
+              style={{ display: 'flex'}}
+            >
               {renderContentByStyle(item)}
             </Grid>
           ))}

--- a/raaghu-components/rds-comp-spinner/rds-comp-spinner.stories.tsx
+++ b/raaghu-components/rds-comp-spinner/rds-comp-spinner.stories.tsx
@@ -54,7 +54,7 @@ type Story = StoryObj<typeof RdsCompSpinner>;
 export const Default: Story = {
     args: {
         layout: SpinnerLayout.LabelAndSpinner,
-        size: SpinnerSize.Small,
+        size: SpinnerSize.Default,
         showLabel: true,
         labelText:"Loading...",
         spinnerType: 'border',


### PR DESCRIPTION
## Description

> Fixed UI Issues On component gradient text, reviews and spinner.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/56e998cd-6c18-4985-bf58-345c03d115ec" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2543a536-949d-42f5-a927-74b1b415edd3" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0168c9a5-657e-4f44-9a3d-93767ceeb8e1" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5527dc50-6dd3-4afa-9df3-1169a7daa7a4" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/dfc634fa-4dca-4ff3-83bb-f25116ec966f" />

