### PR TITLE
Resolved Bug 2550 : Design System > Skeleton > Control not working as per figma if not required remove it or add that control for respective story

### DIFF
--- a/raaghu-elements/rds-skeleton/rds-skeleton.stories.tsx
+++ b/raaghu-elements/rds-skeleton/rds-skeleton.stories.tsx
@@ -7,6 +7,9 @@ const meta: Meta<typeof RdsSkeleton> = {
   component: RdsSkeleton,
   parameters: {
     layout: 'padded',
+    controls: {
+      include: ['shape', 'frames', 'animated', 'animation', 'width', 'height'],
+    },
   },
   tags: ['autodocs'],
   argTypes: {
@@ -14,11 +17,6 @@ const meta: Meta<typeof RdsSkeleton> = {
       control: 'select',
       options: ['text', 'rectangular', 'rounded', 'circular'],
       description: 'Shape of the skeleton block',
-    },
-    type: {
-      control: 'select',
-      options: ['text', 'rectangular', 'rounded', 'circular'],
-      description: 'Shape variant of the skeleton',
     },
     frames: {
       control: { type: 'number', min: 1, max: 10 },
@@ -116,11 +114,11 @@ export const CardSkeleton: Story = {
   args: {},
   render: () => (
     <Card sx={{ maxWidth: 345 }}>
-      <RdsSkeleton variant="rectangular" width="100%" height={140} frames={1} />
+      <RdsSkeleton shape="rectangular" width="100%" height={140} frames={1} />
       <CardContent>
-        <RdsSkeleton variant="text" sx={{ fontSize: '1.2rem' }} frames={1} />
-        <RdsSkeleton variant="text" frames={1} />
-        <RdsSkeleton variant="text" width="60%" frames={1} />
+        <RdsSkeleton shape="text" sx={{ fontSize: '1.2rem' }} frames={1} />
+        <RdsSkeleton shape="text" frames={1} />
+        <RdsSkeleton shape="text" width="60%" frames={1} />
       </CardContent>
     </Card>
   ),

--- a/raaghu-elements/rds-skeleton/rds-skeleton.tsx
+++ b/raaghu-elements/rds-skeleton/rds-skeleton.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Skeleton as MuiSkeleton, type SkeletonProps, Box } from '@mui/material';
 
 export interface RdsSkeletonProps extends SkeletonProps {
-  type?: 'text' | 'rectangular' | 'rounded' | 'circular';
   lines?: number;
   /**
    * Number of skeleton blocks to show in a row/column
@@ -21,9 +20,8 @@ export interface RdsSkeletonProps extends SkeletonProps {
 }
 
 const RdsSkeleton= ({
-  type = 'text',
   lines = 1,
-  shape,
+  shape = 'text',
   frames = 1,
   animated = true,
   animation,


### PR DESCRIPTION
## Description
> Resolve the issues on Element: 
- skeleton: 
  - type control not working for default story if not required remove it or add that control for respective story.
  - removed unused control here.
  
## Screenshots :
 
<img width="800" height="412" alt="image" src="https://github.com/user-attachments/assets/49aa0c09-ffe7-4635-abf2-fb4936955a6d" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
