### PR TITLE
Resolved Bug 2595 : Design System > Adaptive cards > Apart from default story other stories circle icon and title there is to much gap reduce it

### DIFF
--- a/raaghu-components/rds-comp-adaptive-cards/rds-comp-adaptive-cards.scss
+++ b/raaghu-components/rds-comp-adaptive-cards/rds-comp-adaptive-cards.scss
@@ -153,7 +153,6 @@
   }
   &__action-btn {
     font-size: var(--rds-font-size-md, 13px);
-    padding: var(--rds-spacing-xs, 6px) var(--rds-spacing-md, 16px) !important;
     min-height: var(--rds-component-button-height-small, 32px);
     text-transform: none !important;
   }
@@ -1053,3 +1052,6 @@
  {
   margin-left: 0px !important; // Ensure consistent bottom padding
  }
+ .css-1x4jos1 > :not(style) ~ :not(style) {
+    margin-left: 0px !important;
+}

--- a/raaghu-components/rds-comp-adaptive-cards/rds-comp-adaptive-cards.stories.tsx
+++ b/raaghu-components/rds-comp-adaptive-cards/rds-comp-adaptive-cards.stories.tsx
@@ -263,7 +263,6 @@ export const RestaurantOrder: StoryObj<typeof RdsCompAdaptiveCards> = {
 export const FootballScorecard: StoryObj<typeof RdsCompAdaptiveCards> = {
     args: {
         type: 'FootballScorecard',
-        closeIcon: true,
         leagueName: 'La Liga',
         leagueAvatar: 'assets/scorecard1.png',
         isLive: true,
@@ -283,7 +282,7 @@ export const FootballScorecard: StoryObj<typeof RdsCompAdaptiveCards> = {
     parameters: {
         controls: {
             include: [
-                'type', 'closeIcon', 'leagueName', 'leagueAvatar', 'isLive', 'matchDate', 'isFinal', 'homeTeamName', 'homeTeamLogo', 'homeTeamStatus', 'awayTeamName', 'awayTeamLogo', 'awayTeamStatus', 'homeScore', 'awayScore', 'time', 'finalText'
+                'type', 'leagueName', 'leagueAvatar', 'isLive', 'matchDate', 'isFinal', 'homeTeamName', 'homeTeamLogo', 'homeTeamStatus', 'awayTeamName', 'awayTeamLogo', 'awayTeamStatus', 'homeScore', 'awayScore', 'time', 'finalText'
             ],
         },
     },


### PR DESCRIPTION
## Description

- apart from default story other stories circle icon and title there is to much gap reduce it
- football scorecard stories closeicon control remove it,
-  in activity update card story -> in small screen size click here button not looking proper

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/38d5452d-6871-4f1a-8063-4ff390258e4b" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/37c12fde-aff1-4649-b53f-825d637df83b" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6f9b1a09-0f9e-4ac7-9144-fbad5d0c4dc7" />

