### PR TITLE
Resolved Bug 2675 : App Bar Dark Theme Issue

### DIFF
--- a/raaghu-elements/rds-app-bar/rds-app-bar.scss
+++ b/raaghu-elements/rds-app-bar/rds-app-bar.scss
@@ -559,4 +559,8 @@
   // Optional: search field specific
   --rds-header__search-field-bg: var(--rds-background-surface, #23272b);
   --rds-header__search-field-color: var(--rds-text-primary, #e3e3e3);
+
+  .rds-appbar-logo-label{
+    color: var(--rds-color-on-info, #ffffff);
+  }
 }


### PR DESCRIPTION
## Description
> Resolve the dark theme issue from App Bar: 
-  **App Bar**
-In dark theme there is no any white name logo so thats why its not applied.
## Screenshots :
 -e-signature name should be white in dark theme.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b474e5ba-b28d-425c-9ccf-3e9718eee555" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
 