### PR TITLE
Resolved Bug 2637: Design System > Kanban Board > Small screen size it’s going little be outside

### DIFF
--- a/raaghu-components/rds-comp-kanban-board/rds-comp-kanban-board.scss
+++ b/raaghu-components/rds-comp-kanban-board/rds-comp-kanban-board.scss
@@ -568,20 +568,37 @@
   }
 }
 
-// // Responsive adjustments
-// @media (max-width: 600px) {
-//   .add-board {
-//     width: 100% !important;
-//     min-width: 280px !important;
-//   }
-// }
+// Responsive adjustments for small screens
+@media (max-width: 768px) {
+  .rds-kanban-board-container {
+    padding: 0px 16px 5px !important; /* top, sides, bottom */
+    gap: 8px !important;
+    justify-content: center !important;
+    align-items: center !important;
+  }
 
-// @media (max-width: 900px) {
-//   .kanban-board .MuiCard-root {
-//   /* Keep mobile consistent with content-driven height */
-//   min-height: auto !important;
-//   }
-// }
+  .kanban-board {
+    width: calc(100vw - 40px) !important;
+    min-width: calc(100vw - 40px) !important;
+    max-width: calc(100vw - 40px) !important;
+    margin-right: 0px !important;
+    margin-left: 0px !important;
+
+    &__card {
+      min-width: 100% !important;
+      
+      &--add-board-320,
+      &--add-board-280 {
+        min-width: 100% !important;
+      }
+    }
+  }
+
+  .add-board {
+    width: 100% !important;
+    min-width: 100% !important;
+  }
+}
 
 // Dark theme specific styling for dropdown menus
 .dropdown-menu {


### PR DESCRIPTION
## Description
> Resolve the issues on Component kanban board for responsive mode for small, large and tablet screens.

## Screenshots:
1.small screen:
<img width="1920" height="963" alt="image" src="https://github.com/user-attachments/assets/23751375-152a-4e8e-a6da-2e7c1e86eaa1" />

2.large screen:
<img width="1919" height="979" alt="image" src="https://github.com/user-attachments/assets/3c6bc20a-7d37-455b-8d80-56aa823e9f26" />

 
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes