### PR TITLE
Resolved Bug 2717: Design System > Dark theme > Avatar > Initials do not see in dark mode

### DIFF
--- a/raaghu-elements/rds-avatar/rds-avatar.scss
+++ b/raaghu-elements/rds-avatar/rds-avatar.scss
@@ -248,8 +248,10 @@
   }
   &--dark {
     background-color: var(--rds-color-dark, #22223b);
+    color: white;
     .rds-avatar__ring { border-color: var(--rds-color-dark, #22223b); }
     .rds-avatar__dot { background: var(--rds-color-dark, #22223b); }
+    .MuiAvatar-root { color: white !important; }
   }
 
 
@@ -423,4 +425,10 @@
   width: 64px;
   height: 64px;
   font-size: 18px;
+}
+
+html.theme-dark .rds-avatar .MuiAvatar-root,
+[data-theme="dark"] .rds-avatar .MuiAvatar-root,
+.rds-avatar--dark .MuiAvatar-root {
+  color: white !important;
 }


### PR DESCRIPTION
## Description
> Resolved the issues on Element Avatar for initials do not see as white in dark mode

## Screenshots:
1.Default:
<img width="1920" height="956" alt="image" src="https://github.com/user-attachments/assets/af9eab94-57e6-4721-8a4e-e9d22819e381" />

2.With Initials:
<img width="1920" height="913" alt="image" src="https://github.com/user-attachments/assets/96e10316-de0e-4e31-a0ae-ca06a0d4a009" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes