### PR TITLE
Resolved Bug 2695 :  Fab All Stories Inside Icon Or Text Should Be In White Color

### DIFF
--- a/raaghu-elements/rds-fab/rds-fab.scss
+++ b/raaghu-elements/rds-fab/rds-fab.scss
@@ -3,3 +3,25 @@
   display: block;
   position: relative;
 }
+/* Common ancestor-based dark hooks */
+body.dark .MuiFab-root,
+html.dark .MuiFab-root,
+.dark .MuiFab-root,
+[data-theme='dark'] .MuiFab-root,
+.rds-theme--dark .MuiFab-root,
+
+/* component modifier */
+.rds-fab--dark,
+.rds-fab--dark .MuiFab-root {
+  /* set color on the root so text nodes inherit it */
+  color: var(--rds-color-on-surface, #ffffff) !important;
+
+  /* ensure label and icons are explicitly white */
+  .MuiFab-label,
+  span,
+  svg,
+  .MuiSvgIcon-root {
+    color: var(--rds-color-on-surface, #ffffff) !important;
+    fill: currentColor !important;
+  }
+}

--- a/raaghu-elements/rds-fab/rds-fab.tsx
+++ b/raaghu-elements/rds-fab/rds-fab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Fab as MuiFab, FabProps } from '@mui/material';
+import './rds-fab.scss';
 
 export interface RdsFabProps extends FabProps {
   icon?: React.ReactNode;


### PR DESCRIPTION

## Description
> Resolve the issues  All Stories Inside Icon Or Text Should Be In White Color
-  **Fab**

## Screenshots :
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/804fbf3b-ff81-4e2f-b044-b28e389a7017" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4d9340fc-4432-48b2-b8be-0cc232bc67c1" /> 
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
 