### PR TITLE
Resolved Bug 2696 :  Progress Bar Stepper Type Proper Not Show In Dark Theme

### DIFF
--- a/raaghu-elements/rds-progress/rds-progress.scss
+++ b/raaghu-elements/rds-progress/rds-progress.scss
@@ -201,6 +201,13 @@
         color: var(--rds-color-gray-500, #9e9e9e);
         // Muted appearance for steps not yet reached
       }
+      &--number.rds-progress__stepper-step--completed .rds-progress__stepper-number,
+      &--number.rds-progress__stepper-step--current .rds-progress__stepper-number {
+        color: var(--rds-color-white, #ffffff);
+      }
+      &--number.rds-progress__stepper-step--upcoming .rds-progress__stepper-number {
+        color: var(--rds-color-gray-500, #9e9e9e);
+      }
     }
 
     // Responsive: Reduce step size for small and large mobile views and override inline styles
@@ -288,6 +295,77 @@
     .rds-progress__stepper-connector {
       height: 3px;
       // Thicker connector lines
+    }
+  }
+
+  // Additional stepper type modifiers & dark theme overrides (migrated from inline styles)
+  &__stepper {
+    // Type-specific base adjustments
+    &-step {
+  // Circle / number type markers identified via extra modifier class names applied from TSX
+
+      // Circle type: current step should be filled (override default current style)
+  &--circle.rds-progress__stepper-step--current {
+        background-color: var(--progress-color);
+        color: var(--rds-color-white, #ffffff);
+        border-color: var(--progress-color);
+      }
+
+      // Number type: current step filled (override default current style)
+  &--number.rds-progress__stepper-step--current {
+        background-color: var(--progress-color);
+        color: var(--rds-color-white, #ffffff);
+        border-color: var(--progress-color);
+      }
+
+      // Inner dot for circle type
+      .rds-progress__stepper-inner-dot {
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        border: 2px solid var(--rds-color-gray-600, #5c6870);
+        background: transparent;
+        transition: all var(--rds-transition-duration, 0.2s) ease-in-out;
+      }
+
+  &--circle.rds-progress__stepper-step--completed .rds-progress__stepper-inner-dot,
+  &--circle.rds-progress__stepper-step--current .rds-progress__stepper-inner-dot {
+        border-color: var(--rds-color-white, #ffffff);
+        background: transparent;
+      }
+    }
+  }
+
+  // Dark theme overrides
+  :root[data-theme='dark'] &,
+  .theme-dark & {
+    &__stepper {
+      &-step {
+        // Upcoming circle (outer) in dark: black bg, white border/text
+  &--circle.rds-progress__stepper-step--upcoming {
+          background-color: var(--rds-color-surface-dark, #000000);
+          border-color: var(--rds-color-white, #ffffff);
+          color: var(--rds-color-white, #ffffff);
+        }
+        // Upcoming number in dark: black bg, white border/text
+  &--number.rds-progress__stepper-step--upcoming {
+          background-color: var(--rds-color-surface-dark, #000000);
+          border-color: var(--rds-color-white, #ffffff);
+          color: var(--rds-color-white, #ffffff);
+        }
+        // Inner dot upcoming dark
+  &--circle.rds-progress__stepper-step--upcoming .rds-progress__stepper-inner-dot {
+          background-color: var(--rds-color-surface-dark, #000000);
+          border-color: var(--rds-color-white, #ffffff);
+        }
+      }
+      // Connector default in dark (not completed) -> white line
+      &-connector {
+        background-color: var(--rds-color-white, #ffffff);
+      }
+      &-connector--completed {
+        background-color: var(--progress-color);
+      }
     }
   }
 }

--- a/raaghu-elements/rds-progress/rds-progress.tsx
+++ b/raaghu-elements/rds-progress/rds-progress.tsx
@@ -81,6 +81,7 @@ const RdsProgress = ({
 
   const renderStepper = () => {
     const currentStep = Math.ceil(((finalValue || 0) / 100) * totalSteps);
+  const isDark = typeof document !== 'undefined' && (document.documentElement.getAttribute('data-theme') === 'dark' || document.body.classList.contains('theme-dark'));
     return (
       <div className={`rds-progress rds-progress--stepper rds-progress--${color}`}>
         <Box sx={{ display: 'flex', alignItems: 'center', ...sx }} className="rds-progress__stepper">
@@ -89,25 +90,24 @@ const RdsProgress = ({
             const isCompleted = index < currentStep;
             const isCurrent = index === currentStep - 1;
             const stepClass = isCompleted ? 'completed' : isCurrent ? 'current' : 'upcoming';
-            
+            const typeClass = stepperType === 'circle' ? 'rds-progress__stepper-step--circle' : 'rds-progress__stepper-step--number';
             return (
               <React.Fragment key={index}>
                 <Box
-                  className={`rds-progress__stepper-step rds-progress__stepper-step--${stepClass}`}
-                  sx={{
-                    width: 40, height: 40, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'all 0.2s ease-in-out',
-                    border: `2px solid ${colorValue}`,
-                    backgroundColor: stepperType === 'circle' && (isCompleted || isCurrent) ? colorValue : (stepperType === 'number' && isCompleted ? colorValue : 'white'),
-                  }}
+                  className={`rds-progress__stepper-step ${typeClass} rds-progress__stepper-step--${stepClass}`}
+                  sx={{ width: 40, height: 40 }}
                 >
                   {stepperType === 'number' ? (
-                    <Typography variant="body2" sx={{ color: isCompleted ? 'white' : isCurrent ? colorValue : 'var(--rds-color-gray-500, #9e9e9e)', fontWeight: 600, fontSize: '14px' }}>{stepNumber}</Typography>
+                    <Typography variant="body2" className="rds-progress__stepper-number" sx={{ fontWeight: 600, fontSize: '14px' }}>{stepNumber}</Typography>
                   ) : (
-                    <Box sx={{ width: 20, height: 20, borderRadius: '50%', border: `2px solid ${(isCompleted || isCurrent) ? 'white' : 'var(--rds-color-gray-600, #5c6870)'}`, backgroundColor: 'transparent' }} />
+                    <span className="rds-progress__stepper-inner-dot" />
                   )}
                 </Box>
                 {index < totalSteps - 1 && (
-                  <Box className={`rds-progress__stepper-connector ${isCompleted ? 'rds-progress__stepper-connector--completed' : ''}`} sx={{ width: 60, height: 2, backgroundColor: colorValue, transition: 'background-color 0.2s ease-in-out' }} />
+                  <Box
+                    className={`rds-progress__stepper-connector ${isCompleted ? 'rds-progress__stepper-connector--completed' : ''}`}
+                    sx={{ width: 60, height: 2 }}
+                  />
                 )}
               </React.Fragment>
             );


### PR DESCRIPTION
## Description
> Resolve the issues in Progress Bar Stepper  Type Not Show In Dark Theme
-  **Progress Bar**

## Screenshots :
 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f6b20a91-0774-46e3-9197-2f06a04e47da" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e31645ce-7fde-4b0a-aa06-26172377d763" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes