### PR TITLE
Resolved Bug 2715, 2726 : Snackbar And Speed Dial dark theme issue

### DIFF
--- a/raaghu-elements/rds-snackbar/rds-snackbar.stories.tsx
+++ b/raaghu-elements/rds-snackbar/rds-snackbar.stories.tsx
@@ -39,9 +39,6 @@ const SnackbarTemplate = (args: any) => {
 
   return (
     <>
-      {/* <Button variant="contained" onClick={() => setOpen(true)}>
-        Show Snackbar
-      </Button> */}
       <RdsButton
           color="primary"
           layout="text-only"

--- a/raaghu-elements/rds-snackbar/rds-snackbar.stories.tsx
+++ b/raaghu-elements/rds-snackbar/rds-snackbar.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import RdsSnackbar from './rds-snackbar';
-import { Button } from '@mui/material';
 import { useState } from 'react';
+import RdsButton from '../rds-button/rds-button';
 
 const meta: Meta<typeof RdsSnackbar> = {
   title: 'Elements/Snackbar',
@@ -39,9 +39,20 @@ const SnackbarTemplate = (args: any) => {
 
   return (
     <>
-      <Button variant="contained" onClick={() => setOpen(true)}>
+      {/* <Button variant="contained" onClick={() => setOpen(true)}>
         Show Snackbar
-      </Button>
+      </Button> */}
+      <RdsButton
+          color="primary"
+          layout="text-only"
+          shape="rectangle"
+          size="medium"
+          state="default"
+          style="filled"
+          text="Show Snackbar"
+          textCase="unset"
+          onClick={() => setOpen(true)}
+        />
       <RdsSnackbar
         {...args}
         open={open}


### PR DESCRIPTION

## Description
> Resolve the issues in  Snackbar And Speed Dial dark theme issue.
> Icon and text color should be white in dark theme.

-  **Snackbar**
-  **Speed Dial**

## Screenshots :
 <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5794487f-3e46-4e63-9b3c-a1b57535ff69" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8a6cf0f2-c27a-45ce-bc1b-571a8982a766" />
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
 