### PR TITLE
Resolved Bug 2713 : Design system > Dark theme > Toast > Dark mode is on, and layout is downloading the "GO TO DOWNLOADS" text should be in white color.

### DIFF
--- a/raaghu-components/rds-comp-toast/rds-comp-toast.scss
+++ b/raaghu-components/rds-comp-toast/rds-comp-toast.scss
@@ -226,7 +226,7 @@
   }
 
   &--chat &__title {
-    color: #353535; 
+    color: var(--rds-color-on-surface-dark, #353535);
     font-weight: 500;
   }
   
@@ -552,5 +552,22 @@
     &::placeholder {
       color: var(--rds-color-on-surface-variant-dark, #cccccc);
     }
+  }
+
+  .rds-comp-toast__icon--circle {
+    --rds-toast-circle-color: var(--rds-color-on-surface-dark, #ffffff);
+  }
+  .rds-comp-toast__icon--plus {
+    --rds-toast-plus-color: var(--rds-color-on-surface-dark, #ffffff);
+  }
+
+  /* Ensure all button text is readable/white in dark theme without changing behaviors */
+  &__close-btn {
+    color: var(--rds-color-on-surface-dark, #ffffff);
+  }
+
+  .css-1goqzru-MuiButtonBase-root-MuiButton-root,
+  .css-kicv99-MuiButtonBase-root-MuiButton-root {
+    color: var(--rds-color-on-surface-dark, #ffffff);
   }
 }


### PR DESCRIPTION
## Description
> Resolve the issues on Component: 
- Toast:
  - when dark mode is on and layout is downloading the "GO TO DOWNLOADS" text should be in white color.
  - when dark mode is on and layout is Chat the "Reply" text should be in white color.
  - when dark mode is on and layout is Request the "Accepts" text should be in white color.
  
## Screenshots :
 
<img width="800" height="412" alt="image" src="https://github.com/user-attachments/assets/817fdc47-f295-4739-8784-71b81bcdfa28" />
<img width="1918" height="982" alt="image" src="https://github.com/user-attachments/assets/76ea16e5-c114-4b3c-9d9d-43a9386ed56e" />
<img width="1916" height="984" alt="image" src="https://github.com/user-attachments/assets/1520a385-3300-4065-8c1e-b08f8f50f1d4" />
<img width="1916" height="989" alt="image" src="https://github.com/user-attachments/assets/f28d91f7-8e27-4ecd-b831-01b7e7c4acc2" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
