### PR TITLE
Resolved Bug 2689 : Design System > Dark theme > Box > When dark mode is on 'with margin ' stories can we change the color of the inside box text, so it's look good in dark mode.

### DIFF
--- a/raaghu-elements/rds-box/rds-box.scss
+++ b/raaghu-elements/rds-box/rds-box.scss
@@ -5,19 +5,60 @@
   display: block;
   position: relative;
 
-  // Interactive states
-  &:hover {
-    // Hover styles
-  }
-
   &:focus-visible {
-    outline: 2px solid var(--rds-color-primary, var(--rds-primary-main));
-    outline-offset: var(--rds-focus-ring-offset);
+    outline: var(--rds-focus-ring-width, 2px) solid var(--rds-color-primary, var(--rds-primary-main));
+    outline-offset: var(--rds-focus-ring-offset, 2px);
   }
 
   &:disabled,
   &--disabled {
-    opacity: 0.6;
+    opacity: var(--rds-opacity-disabled, 0.6);
     pointer-events: none;
+  }
+
+  // Flex container variant for button layouts
+  &--flex-container {
+    display: flex;
+    gap: var(--rds-spacing-md, 16px);
+    padding: var(--rds-spacing-md, 16px);    
+    border: var(--rds-border-width-thin, 1px) solid var(--rds-color-outline, #79747e);
+    justify-content: space-around;
+  }
+
+  // Default variant - basic styling with dashed border
+  &--default {
+    padding: var(--rds-spacing-md, 16px); 
+    border: var(--rds-border-width-thin, 1px) dashed var(--rds-color-outline, #79747e);
+  }
+
+  // With padding variant - prominent background styling
+  &--with-padding {
+    padding: var(--rds-spacing-xl, 32px); 
+    background-color: var(--rds-color-primary, #1976d2);
+    color: var(--rds-color-on-primary, #ffffff);
+  }
+
+  // With margin variant - margin and background styling
+  &--with-margin {
+    margin: var(--rds-spacing-md, 16px); 
+    padding: var(--rds-spacing-md, 16px); 
+    background-color: var(--rds-color-secondary, #e91e63);
+    color: var(--rds-color-on-secondary, #ffffff);
+  }
+
+  // Grid container variant for grid layouts
+  &--grid-container {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--rds-spacing-md, 16px); 
+    padding: var(--rds-spacing-md, 16px); 
+    border: var(--rds-border-width-thin, 1px) solid var(--rds-color-outline, #79747e);
+  }
+
+  // Custom component variant - blue background
+  &--custom-component {
+    padding: var(--rds-spacing-md, 16px); 
+    background-color: var(--rds-color-tertiary, #03a9f4);
+    color: var(--rds-color-on-tertiary, #ffffff);
   }
 }

--- a/raaghu-elements/rds-box/rds-box.stories.tsx
+++ b/raaghu-elements/rds-box/rds-box.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import RdsBox from './rds-box';
-import { Button, Typography } from '@mui/material';
+import {Typography } from '@mui/material';
 import RdsButton from '../rds-button/rds-button';
 
 const meta: Meta<typeof RdsBox> = {
@@ -15,7 +15,8 @@ const meta: Meta<typeof RdsBox> = {
   argTypes: {
   // define the controls we want visible in Controls panel
   children: { control: { type: 'text' } },
-  sx: { control: { type: 'object' } },
+  // Hide className from controls and code display
+  className: { table: { disable: true }, control: false },
   },
 };
 
@@ -25,28 +26,56 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     children: 'This is a Box component',
-    sx: { p: 2, border: '1px dashed grey' },
   },
+  render: (args) => <RdsBox {...args} className="rds-box--default" />,
+  parameters: {
+    docs: {
+      source: {
+        code: `<RdsBox>
+        This is a Box component
+        </RdsBox>`
+      }
+    }
+  }
 };
 
 export const WithPadding: Story = {
   args: {
     children: 'Box with padding',
-    sx: { p: 4, backgroundColor: '#2196f3', color: 'white' },
   },
+  render: (args) => <RdsBox {...args} className="rds-box--with-padding" />,
+  parameters: {
+    docs: {
+      source: {
+        code: `<RdsBox>
+        Box with padding
+        </RdsBox>`
+      }
+    }
+  }
 };
 
 export const WithMargin: Story = {
   args: {
     children: 'Box with margin',
-    sx: { m: 2, p: 2, backgroundColor: '#e91e63', color: 'white' },
   },
+  render: (args) => <RdsBox {...args} className="rds-box--with-margin" />,
+  parameters: {
+    docs: {
+      source: {
+        code: `<RdsBox>
+        Box with margin
+        </RdsBox>`
+      }
+    }
+  }
 };
 
 export const FlexContainer: Story = {
   args: {
     children: [
   <RdsButton
+  key="1"
   color="primary"
   layout="text-only"
   shape="rectangle"
@@ -57,6 +86,7 @@ export const FlexContainer: Story = {
   textCase="capitalize"
 />,
  <RdsButton
+  key="2"
   color="primary"
   layout="text-only"
   shape="rectangle"
@@ -67,6 +97,7 @@ export const FlexContainer: Story = {
   textCase="capitalize"
 />,
  <RdsButton
+  key="3"
   color="primary"
   layout="text-only"
   shape="rectangle"
@@ -77,14 +108,46 @@ export const FlexContainer: Story = {
   textCase="capitalize"
 />
     ],
-    sx: { 
-      display: 'flex', 
-      gap: 2, 
-      p: 2, 
-      border: '1px solid grey',
-      justifyContent: 'space-around',
-    },
   },
+  render: (args) => <RdsBox {...args} className="rds-box--flex-container" />,
+  parameters: {
+    docs: {
+      source: {
+        code: `<RdsBox>
+  <RdsButton
+    color="primary"
+    layout="text-only"
+    shape="rectangle"
+    size="medium"
+    state="default"
+    style="filled"
+    text="Button 1"
+    textCase="capitalize"
+  />
+  <RdsButton
+    color="primary"
+    layout="text-only"
+    shape="rectangle"
+    size="medium"
+    state="default"
+    style="outlined"
+    text="Button 2"
+    textCase="capitalize"
+  />
+  <RdsButton
+    color="primary"
+    layout="text-only"
+    shape="rectangle"
+    size="medium"
+    state="default"
+    style="transparent"
+    text="Button 3"
+    textCase="capitalize"
+  />
+</RdsBox>`
+      }
+    }
+  }
 };
 
 export const GridContainer: Story = {
@@ -97,20 +160,35 @@ export const GridContainer: Story = {
         <Typography>Item 4</Typography>
       </>
     ),
-    sx: { 
-      display: 'grid', 
-      gridTemplateColumns: 'repeat(2, 1fr)',
-      gap: 2, 
-      p: 2, 
-      border: '1px solid grey',
-    },
   },
+  render: (args) => <RdsBox {...args} className="rds-box--grid-container" />,
+  parameters: {
+    docs: {
+      source: {
+        code: `<RdsBox>
+        <Typography>Item 1</Typography>
+        <Typography>Item 2</Typography>
+        <Typography>Item 3</Typography>
+        <Typography>Item 4</Typography>
+        </RdsBox>`
+      }
+    }
+  }
 };
 
 export const CustomComponent: Story = {
   args: {
     component: 'section',
     children: 'This Box renders as a section element',
-    sx: { p: 2, backgroundColor: '#03a9f4', color: 'white' },
   },
+  render: (args) => <RdsBox {...args} className="rds-box--custom-component" />,
+  parameters: {
+    docs: {
+      source: {
+        code: `<RdsBox component="section">
+        This Box renders as a section element
+        </RdsBox>`
+      }
+    }
+  }
 };

--- a/raaghu-elements/rds-box/rds-box.stories.tsx
+++ b/raaghu-elements/rds-box/rds-box.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import RdsBox from './rds-box';
 import { Button, Typography } from '@mui/material';
+import RdsButton from '../rds-button/rds-button';
 
 const meta: Meta<typeof RdsBox> = {
   title: 'Elements/Box',
@@ -45,9 +46,36 @@ export const WithMargin: Story = {
 export const FlexContainer: Story = {
   args: {
     children: [
-      <Button key="1" variant="contained">Button 1</Button>,
-      <Button key="2" variant="outlined">Button 2</Button>,
-      <Button key="3" variant="text">Button 3</Button>,
+  <RdsButton
+  color="primary"
+  layout="text-only"
+  shape="rectangle"
+  size="medium"
+  state="default"
+  style="filled"
+  text="Button 1"
+  textCase="capitalize"
+/>,
+ <RdsButton
+  color="primary"
+  layout="text-only"
+  shape="rectangle"
+  size="medium"
+  state="default"
+  style="outlined"
+  text="Button 2"
+  textCase="capitalize"
+/>,
+ <RdsButton
+  color="primary"
+  layout="text-only"
+  shape="rectangle"
+  size="medium"
+  state="default"
+  style="transparent"
+  text="Button 3"
+  textCase="capitalize"
+/>
     ],
     sx: { 
       display: 'flex', 

--- a/raaghu-elements/rds-box/rds-box.stories.tsx
+++ b/raaghu-elements/rds-box/rds-box.stories.tsx
@@ -7,8 +7,8 @@ const meta: Meta<typeof RdsBox> = {
   component: RdsBox,
   parameters: {
   layout: 'centered',
-  // only show the `children` and `sx` controls in the Controls panel; hide all other auto-generated props
-  controls: { include: ['children', 'sx'] },
+  // only show the `children` controls in the Controls panel; hide all other auto-generated props
+  controls: { include: ['children'] },
   },
   tags: ['autodocs'],
   argTypes: {
@@ -31,14 +31,14 @@ export const Default: Story = {
 export const WithPadding: Story = {
   args: {
     children: 'Box with padding',
-    sx: { p: 4, backgroundColor: 'primary.light', color: 'white' },
+    sx: { p: 4, backgroundColor: '#2196f3', color: 'white' },
   },
 };
 
 export const WithMargin: Story = {
   args: {
     children: 'Box with margin',
-    sx: { m: 2, p: 2, backgroundColor: 'secondary.light', color: 'white' },
+    sx: { m: 2, p: 2, backgroundColor: '#e91e63', color: 'white' },
   },
 };
 
@@ -83,6 +83,6 @@ export const CustomComponent: Story = {
   args: {
     component: 'section',
     children: 'This Box renders as a section element',
-    sx: { p: 2, backgroundColor: 'info.light', color: 'white' },
+    sx: { p: 2, backgroundColor: '#03a9f4', color: 'white' },
   },
 };

--- a/raaghu-elements/rds-box/rds-box.tsx
+++ b/raaghu-elements/rds-box/rds-box.tsx
@@ -3,6 +3,7 @@ import {
   Box as MuiBox,
   type BoxProps
 } from '@mui/material';
+import './rds-box.scss';
 
 export interface RdsBoxProps extends BoxProps {
   children?: React.ReactNode;
@@ -10,10 +11,14 @@ export interface RdsBoxProps extends BoxProps {
 
 const RdsBox = ({
   children,
+  className,
   ...props
-}:RdsBoxProps) => {
+}:RdsBoxProps & { className?: string }) => {
+  // Combine the base rds-box class with any additional classes
+  const mergedClassName = ['rds-box', className].filter(Boolean).join(' ');
+
   return (
-    <MuiBox {...props}>
+    <MuiBox className={mergedClassName} {...props}>
       {children}
     </MuiBox>
   );


### PR DESCRIPTION
## Description
> Resolve the issues on Element: 
- Box:
   - In padding story in dark mode it's not looking good.
   - when dark mode is on 'with margin ' stories can we change the color of the inside box text.
   - removed unused control.
   - In Flex Container story button text color should be white in dark mode.

## Screenshots :
<img width="1920" height="987" alt="image" src="https://github.com/user-attachments/assets/03c47452-5fd6-401b-8fe3-7f03114e3346" />
<img width="1920" height="986" alt="image" src="https://github.com/user-attachments/assets/00945623-2b87-4a52-ae96-4935ba596e01" />
 <img width="1918" height="982" alt="image" src="https://github.com/user-attachments/assets/1baa51ea-659c-40e0-8e2b-4a896afac121" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
