### PR TITLE
Resolved Bug 2747 : Design system > Dark theme > Stack > Other than responsive story other stories not looking good in dark mode.

### DIFF
--- a/raaghu-elements/rds-stack/rds-stack.scss
+++ b/raaghu-elements/rds-stack/rds-stack.scss
@@ -30,17 +30,49 @@
   }
 }
 
-// Additional selectors targeting MUI's Divider root and its pseudo elements.
-// Sometimes Stack clones or MUI adds its own classes; target the MuiDivider
-// root to ensure the color is applied even if our class is missing.
 .rds-stack .MuiDivider-root,
 .rds-stack .rds-stack__divider {
-  background-color: var(--rds-stack-divider-color, rgba(0, 0, 0, 0.12)) !important;
+  background-color: var(--rds-stack-divider-color, rgba(0, 0, 0, 0.12));
   color: var(--rds-stack-divider-color, rgba(0, 0, 0, 0.12));
-  border-color: var(--rds-stack-divider-color, rgba(0, 0, 0, 0.12)) !important;
+  border-color: var(--rds-stack-divider-color, rgba(0, 0, 0, 0.12));
 }
 
-.rds-stack .MuiDivider-root::before,
-.rds-stack .MuiDivider-root::after {
-  background-color: var(--rds-stack-divider-color, rgba(0, 0, 0, 0.12)) !important;
+.rds-stack__demo-item {
+  padding: 0.25rem 0.5rem; /* p:1 equivalent */
+  border-radius: 4px;
+  font-weight: 500;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: inherit;
+}
+
+.rds-stack__demo-item--primary {
+  background-color: var(--rds-color-primary-light, #1976d2);
+}
+
+.rds-stack__demo-item--secondary {
+  background-color: var(--rds-color-secondary-light, #9c27b0);
+}
+
+.rds-stack__demo-item--success {
+  background-color: var(--rds-color-success-light, #2e7d32);
+}
+
+/* Dark theme overrides (assuming a .dark-theme wrapper is applied) */
+.dark-theme .rds-stack__demo-item--primary {
+  background-color: var(--rds-color-primary-dark, #1976d2);
+}
+.dark-theme .rds-stack__demo-item--secondary {
+  background-color: var(--rds-color-secondary-dark, #9c27b0);
+}
+.dark-theme .rds-stack__demo-item--success {
+  background-color: var(--rds-color-success-dark, #2e7d32);
+}
+.dark-theme .rds-stack .MuiDivider-root,
+.rds-stack .rds-stack__divider {
+  background-color: var(--rds-stack-divider-color, rgba(219, 219, 219, 0.59));
+  color: var(--rds-stack-divider-color, rgba(224, 218, 218, 0.479));
+  border-color: var(--rds-stack-divider-color, rgba(145, 144, 144, 0.621));
 }

--- a/raaghu-elements/rds-stack/rds-stack.stories.tsx
+++ b/raaghu-elements/rds-stack/rds-stack.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Box, Typography } from '@mui/material';
+import {Typography } from '@mui/material';
+import './rds-stack.scss';
 import RdsStack from './rds-stack';
+import RdsBox from '../rds-box/rds-box';
+
 
 const meta: Meta<typeof RdsStack> = {
   title: 'Elements/Stack',
@@ -27,9 +30,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const stackItems = [
-  <Box key="1" sx={{ p: 1, bgcolor: 'primary.light', color: 'white' }}>Item 1</Box>,
-  <Box key="2" sx={{ p: 1, bgcolor: 'secondary.light', color: 'white' }}>Item 2</Box>,
-  <Box key="3" sx={{ p: 1, bgcolor: 'success.light', color: 'white' }}>Item 3</Box>,
+  <RdsBox key="1" className="rds-stack__demo-item rds-stack__demo-item--primary">Item 1</RdsBox>,
+  <RdsBox key="2" className="rds-stack__demo-item rds-stack__demo-item--secondary">Item 2</RdsBox>,
+  <RdsBox key="3" className="rds-stack__demo-item rds-stack__demo-item--success">Item 3</RdsBox>,
 ];
 
 export const Default: Story = {


### PR DESCRIPTION
# Description

> Introduces new SCSS classes for styled demo items in rds-stack, including primary, secondary, and success variants with dark theme support.
> Updates the Storybook story to use RdsBox with these new classes instead of MUI Box, improving visual consistency and theming.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/467ee116-9711-4076-96b9-c3236841a65a" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f37cc695-b463-4af7-b2ef-6cc137495bac" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/35904a5b-22a9-4c8b-b29b-9973a1970741" />

