### PR TITLE
Resolved Bug 2681: Design System > Backdrop > loading story loading circle is not visible in dark themes

### DIFF
--- a/raaghu-elements/rds-backdrop/rds-backdrop.scss
+++ b/raaghu-elements/rds-backdrop/rds-backdrop.scss
@@ -4,15 +4,7 @@
 .rds-backdrop {
   display: block;
   position: relative;
-
-  &--invisible {
-    // Invisible state styles
-  }
-
-  // Interactive states
-  &:hover {
-    // Hover styles
-  }
+  background-color: var(--rds-background-overlay, rgba(0, 0, 0, 0.5));
 
   &:focus-visible {
     outline: 2px solid var(--rds-color-primary, var(--rds-primary-main));
@@ -23,5 +15,21 @@
   &--disabled {
     opacity: 0.6;
     pointer-events: none;
+  }
+
+  // Dark theme support for better backdrop visibility
+  .dark-theme &,
+  [data-theme="dark"] & {
+    background-color: rgba(128, 128, 128, 0.4);
+  }
+
+  // Loading spinner visibility in dark theme
+  .MuiCircularProgress-root {
+    color: var(--rds-text-primary, #000);
+    
+    .dark-theme &,
+    [data-theme="dark"] & {
+      color: var(--rds-text-primary, #fff);
+    }
   }
 }

--- a/raaghu-elements/rds-backdrop/rds-backdrop.tsx
+++ b/raaghu-elements/rds-backdrop/rds-backdrop.tsx
@@ -15,6 +15,7 @@ const RdsBackdrop: React.FC<RdsBackdropProps> = ({
   loadingComponent,
   children,
   open,
+  className = '',
   ...props
 }) => {
   // If `open` is explicitly provided, it takes precedence.
@@ -27,15 +28,27 @@ const RdsBackdrop: React.FC<RdsBackdropProps> = ({
     ? (loadingComponent ?? <CircularProgress color="inherit" />)
     : children;
 
-  // Ensure the spinner is visible by default: apply white color while loading.
-  // Respect any user-provided sx by merging.
+  // Combine our backdrop class with any provided className
+  const backdropClassName = `rds-backdrop ${className}`.trim();
+
+  // Remove the hardcoded color for loading spinner to let CSS handle theme-aware colors
   const { sx, ...restProps } = props as { sx?: any } & typeof props;
-  const mergedSx = loading
-    ? (Array.isArray(sx) ? [{ color: '#130808' }, ...sx] : { color: '#130808', ...sx })
-    : sx;
+
+  // Ensure our custom styles take precedence over Material-UI defaults
+  const backdropSx = {
+    // Apply our custom backdrop styles
+    '&.rds-backdrop': {
+      backgroundColor: 'var(--rds-background-overlay, rgba(0, 0, 0, 0.5))',
+    },
+    // Dark theme override
+    '.dark-theme &.rds-backdrop, [data-theme="dark"] &.rds-backdrop': {
+      backgroundColor: 'rgba(128, 128, 128, 0.4)',
+    },
+    ...sx
+  };
 
   return (
-    <MuiBackdrop open={isOpen} sx={mergedSx} {...restProps}>
+    <MuiBackdrop open={isOpen} className={backdropClassName} sx={backdropSx} {...restProps}>
       {content}
     </MuiBackdrop>
   );
@@ -43,3 +56,4 @@ const RdsBackdrop: React.FC<RdsBackdropProps> = ({
 
 RdsBackdrop.displayName = 'RdsBackdrop';
 export default RdsBackdrop;
+                             


### PR DESCRIPTION
## Description
> Resolved the issues on Element Backdrop loading story loading circle is not visible in dark themes.
> Resolved the issues for interactive story backdrop color should be different.
> Resolved the issues for Default story backdrop color should be different.

## Screenshots:
 1.Default:
<img width="1920" height="992" alt="image" src="https://github.com/user-attachments/assets/3b1fc0a1-6ac5-4212-aefa-232799117a7d" />

2.With Loading:
<img width="1920" height="981" alt="image" src="https://github.com/user-attachments/assets/8c2b635f-5857-48ab-8e5d-61c92f33b395" />

3.Interactive:
<img width="1920" height="987" alt="image" src="https://github.com/user-attachments/assets/863777cc-32f5-4d90-983d-251723ba3da5" />

 
## Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes
 