### PR TITLE
Resolved Bug 2748 : In The Dark Theme, List Title And Avatar Text Are Not Displayed Properly

### DIFF
--- a/raaghu-elements/rds-list/rds-list.scss
+++ b/raaghu-elements/rds-list/rds-list.scss
@@ -298,7 +298,6 @@
   font-size: var(--rds-font-size-body, 16px);
   font-weight: 500;
   margin: var(--rds-spacing-sm, 8px) 0;
-  color: var(--rds-text-primary, #333);
 }
 
 // Demo description
@@ -373,4 +372,11 @@
   .rds-list__item--clickable:hover {
     background-color: var(--rds-overlay-hover, rgba(255, 255, 255, 0.08));
   }
+}
+[data-theme="dark"] {
+.rds-list{
+  .css-155c0ib-MuiAvatar-root {
+    color: var(--rds-color-on-primary,#ffffff);
+  }
+}
 }


### PR DESCRIPTION
## Description
> Resolve the issues In the dark theme, the list title and avatar text now displayed properly.
-  **List**

## Screenshots :
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bca8ccc8-46b3-4b95-ace0-bed5eed4c737" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes