### PR TITLE
Resolved Bug 2701: Design System > Dark theme > Off Canvas > Button that text also in white color when dark mode is on

### DIFF
--- a/raaghu-components/rds-comp-off-canvas/rds-comp-off-canvas.scss
+++ b/raaghu-components/rds-comp-off-canvas/rds-comp-off-canvas.scss
@@ -123,12 +123,6 @@
   transition: all 0.2s ease-in-out;
   border-radius: 5px;
 }
-#close-btn .rds-icon-button:hover,
-#close-btn .MuiIconButton-root:hover {
-  background: aliceblue;
-  border-radius: 5px;
-  transition: all 0.2s ease-in-out;
-}
 
 @media (min-width: 320px) and (max-width: 414px) {
   .offcanvas-drawer .MuiDrawer-paper {


### PR DESCRIPTION
## Description
> Resolve the issues on Element Off-Canvas for OPEN OFF CANVAS" text should be in white color.
>Resolved issue there is same button that text also in white color when dark mode is on.

## Screenshots:

1.Default (Dark Mode):
<img width="1920" height="987" alt="image" src="https://github.com/user-attachments/assets/10b3df43-0285-4ef1-b4b6-78288cddade3" />
 
## Checklist:

- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] I have added tests that prove my fix is effective or that my feature works

- [x] New and existing unit tests pass locally with my changes
 