### PR TITLE
Resolved Bug 2739 : Design system > Dark theme > Timeline > All stories the secondary text is not visible in dark mode.

### DIFF
--- a/raaghu-elements/rds-timeline/rds-timeline.scss
+++ b/raaghu-elements/rds-timeline/rds-timeline.scss
@@ -41,3 +41,29 @@
     pointer-events: none;
   }
 }
+
+// Dark theme support for timeline
+[data-theme="dark"],
+.dark-theme {
+  .MuiTimeline-root {
+    .MuiTimelineOppositeContent-root {
+      color: var(--rds-text-secondary);
+    }
+    
+    // Timeline description text styling for dark theme
+    .MuiTimelineContent-root {
+      div {
+        color: var(--rds-text-secondary) !important;
+      }
+    }
+  }
+}
+
+// Light theme (default) description color
+.MuiTimeline-root {
+  .MuiTimelineContent-root {
+    div {
+      color: var(--rds-text-secondary);
+    }
+  }
+}

--- a/raaghu-elements/rds-timeline/rds-timeline.tsx
+++ b/raaghu-elements/rds-timeline/rds-timeline.tsx
@@ -54,7 +54,7 @@ const RdsTimeline: React.FC<RdsTimelineProps> = ({
             <MuiTimelineContent>
               <strong>{item.title}</strong>
               {item.description && (
-                <div style={{ marginTop: 4, color: 'rgba(0, 0, 0, 0.6)' }}>
+                <div style={{ marginTop: 4 }}>
                   {item.description}
                 </div>
               )}


### PR DESCRIPTION
## Description
> Resolve the issues on Element: 
- Timeline:
  - All stories the secondary text is not visible in dark mode.
  
## Screenshots :
 
<img width="800" height="411" alt="image" src="https://github.com/user-attachments/assets/b1718582-047d-4059-b060-9955a6c073d1" />
<img width="1920" height="980" alt="image" src="https://github.com/user-attachments/assets/71eedf65-b4ea-43cb-8c6e-78fb5d21d0dc" />
<img width="1914" height="982" alt="image" src="https://github.com/user-attachments/assets/73c9ebfb-b3c0-484e-9083-6525b5a00cb2" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
