### PR TITLE
Resolved Bug 2756 : Design System > Toggle Button > Apart from without icons, vertical buttons and standalone toggle buttons these stories other stories are not looking good in small mobile size.

### DIFF
--- a/raaghu-elements/rds-toggle-button/rds-toggle-button.scss
+++ b/raaghu-elements/rds-toggle-button/rds-toggle-button.scss
@@ -134,6 +134,32 @@
   max-width: 100%;
 }
 
+// Size modifiers
+.rds-toggle-button--small .rds-toggle-button__button { 
+  font-size: var(--rds-font-size-sm, 0.75rem); 
+  padding: var(--rds-spacing-xs,4px) var(--rds-spacing-sm,8px); 
+  min-height: 32px;
+}
+.rds-toggle-button--medium .rds-toggle-button__button { 
+  font-size: var(--rds-font-size-md, 0.875rem); 
+  padding: var(--rds-spacing-sm,8px) var(--rds-spacing-md,12px); 
+  min-height: 36px;
+}
+.rds-toggle-button--large .rds-toggle-button__button { 
+  font-size: var(--rds-font-size-lg, 1rem); 
+  padding: var(--rds-spacing-md,12px) var(--rds-spacing-lg,16px); 
+  min-height: 44px;
+}
+
+// Adjust sizes slightly on very narrow phones to prevent truncation
+@media (max-width:400px){
+  .rds-toggle-button--large .rds-toggle-button__button { 
+    padding: var(--rds-spacing-sm,8px) var(--rds-spacing-md,12px); 
+    font-size: var(--rds-font-size-md,0.875rem);
+    min-height: 40px;
+  }
+}
+
 // Allow custom spaced group to also wrap when required
 .rds-toggle-button--spaced .rds-toggle-button__custom-group {
   display: flex;
@@ -155,11 +181,23 @@
 
   // Make every button flex equally so the longest label doesn't force overflow
   .rds-toggle-button__group .MuiToggleButton-root,
-  .rds-toggle-button__button {
-    min-width: 0; // allow shrink below intrinsic width
-    padding: 6px 9px;
-    font-size: 0.75rem;
-    box-sizing: border-box;
+  .rds-toggle-button__button { 
+    min-width:0; 
+    box-sizing:border-box; // keep structural adjustments only
+  }
+
+  // Size-specific scaling on very small viewports so control remains distinguishable
+  .rds-toggle-button--small .rds-toggle-button__button { 
+    font-size: var(--rds-font-size-xs,0.7rem); 
+    padding: 4px 6px; 
+  }
+  .rds-toggle-button--medium .rds-toggle-button__button { 
+    font-size: var(--rds-font-size-sm,0.8rem); 
+    padding: 6px 8px; 
+  }
+  .rds-toggle-button--large .rds-toggle-button__button { 
+    font-size: var(--rds-font-size-md,0.9rem); 
+    padding: 8px 12px; 
   }
 
   .rds-toggle-button__icon { margin-right: 4px !important; }
@@ -186,6 +224,22 @@
   }
   // Ensure flex chain doesn't create min-content overflow
   .rds-toggle-button--spaced .rds-toggle-button__custom-group { min-width:0; flex-wrap:wrap; }
+
+  // 2 + 1 layout for large size groups with exactly 3 options
+  .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical):not(.rds-toggle-button--spaced) .rds-toggle-button__group,
+  .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical).rds-toggle-button--spaced .rds-toggle-button__custom-group {
+    flex-wrap: wrap;
+  }
+  .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical) .MuiToggleButton-root,
+  .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical) .rds-toggle-button__button {
+    flex:1 1 50%;
+    max-width:50%;
+  }
+  .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical) .MuiToggleButton-root:nth-child(3),
+  .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical) .rds-toggle-button__button-wrapper:nth-child(3) .rds-toggle-button__button {
+    flex:1 1 100%;
+    max-width:100%;
+  }
 
   // Fallback: if still overflowing for edge locales, allow wrap cleanly
   @supports (flex-wrap: wrap) {

--- a/raaghu-elements/rds-toggle-button/rds-toggle-button.scss
+++ b/raaghu-elements/rds-toggle-button/rds-toggle-button.scss
@@ -174,4 +174,14 @@
       flex-wrap: wrap;
     }
   }
+
+  // Automatic wrapping variant (added when option count > 3)
+  .rds-toggle-button--wrap-mobile .rds-toggle-button__group,
+  .rds-toggle-button--wrap-mobile.rds-toggle-button--spaced .rds-toggle-button__custom-group {
+    flex-wrap: wrap;
+  }
+  .rds-toggle-button--wrap-mobile .MuiToggleButton-root,
+  .rds-toggle-button--wrap-mobile .rds-toggle-button__button {
+    flex: 1 1 50%; // two per row
+  }
 }

--- a/raaghu-elements/rds-toggle-button/rds-toggle-button.scss
+++ b/raaghu-elements/rds-toggle-button/rds-toggle-button.scss
@@ -175,13 +175,42 @@
     }
   }
 
-  // Automatic wrapping variant (added when option count > 3)
-  .rds-toggle-button--wrap-mobile .rds-toggle-button__group,
-  .rds-toggle-button--wrap-mobile.rds-toggle-button--spaced .rds-toggle-button__custom-group {
-    flex-wrap: wrap;
+}
+
+
+  // Automatic wrapping variant (added when option count > 3) - MOBILE ONLY (<=600px)
+  // We intentionally restrict wrapping to small screens; tablet & desktop remain single row.
+  @media (max-width: 600px) {
+    .rds-toggle-button--wrap-mobile .rds-toggle-button__group,
+    .rds-toggle-button--wrap-mobile.rds-toggle-button--spaced .rds-toggle-button__custom-group {
+      flex-wrap: wrap;
+    }
+    .rds-toggle-button--wrap-mobile .MuiToggleButton-root,
+    .rds-toggle-button--wrap-mobile .rds-toggle-button__button {
+      flex: 1 1 50%; // two per row
+    }
   }
-  .rds-toggle-button--wrap-mobile .MuiToggleButton-root,
-  .rds-toggle-button--wrap-mobile .rds-toggle-button__button {
-    flex: 1 1 50%; // two per row
+
+// Large mobile / small handset landscape (covers widths like 414px iPhone and up to small tablets)
+@media (min-width:401px) and (max-width: 600px) {
+  .rds-toggle-button { width:100%; max-width:100%; }
+
+  .rds-toggle-button__group,
+  .rds-toggle-button--spaced .rds-toggle-button__custom-group { 
+    flex-wrap: nowrap; 
+    width:100%;
+    max-width:100%;
   }
+
+  .rds-toggle-button__group .MuiToggleButton-root,
+  .rds-toggle-button__button { 
+    flex:1 1 0; 
+    min-width:0; 
+    padding:6px 10px; 
+    font-size:0.8rem; 
+    box-sizing:border-box; 
+  }
+
+  // Spaced variant margin neutralization to avoid overflow
+  .rds-toggle-button--spaced .rds-toggle-button__button-wrapper { margin-left:0 !important; }
 }

--- a/raaghu-elements/rds-toggle-button/rds-toggle-button.scss
+++ b/raaghu-elements/rds-toggle-button/rds-toggle-button.scss
@@ -126,3 +126,52 @@
     justify-content: center;
   }
 }
+
+// Ensure the internal MUI group respects flex and can wrap when needed
+.rds-toggle-button__group {
+  display: flex;
+  flex-wrap: nowrap; // default (desktop)
+  max-width: 100%;
+}
+
+// Allow custom spaced group to also wrap when required
+.rds-toggle-button--spaced .rds-toggle-button__custom-group {
+  display: flex;
+  flex-wrap: nowrap; // default
+  max-width: 100%;
+}
+
+// Small mobile responsiveness (prevents horizontal scrollbar at <= 400px width)
+@media (max-width: 400px) {
+  .rds-toggle-button { width: 100%; max-width:100%; }
+
+  .rds-toggle-button__group,
+  .rds-toggle-button--spaced .rds-toggle-button__custom-group {
+    flex-wrap: nowrap;
+    overflow: hidden; // hide any stray pixel overflow
+    width: 100%;
+    max-width:100%;
+  }
+
+  // Make every button flex equally so the longest label doesn't force overflow
+  .rds-toggle-button__group .MuiToggleButton-root,
+  .rds-toggle-button__button {
+    min-width: 0; // allow shrink below intrinsic width
+    padding: 6px 9px;
+    font-size: 0.75rem;
+    box-sizing: border-box;
+  }
+
+  .rds-toggle-button__icon { margin-right: 4px !important; }
+
+  // Spaced variant: remove horizontal margins that create overflow
+  .rds-toggle-button--spaced .rds-toggle-button__button-wrapper { margin-left: 0 !important; }
+
+  // Fallback: if still overflowing for edge locales, allow wrap cleanly
+  @supports (flex-wrap: wrap) {
+    .rds-toggle-button.is-wrap .rds-toggle-button__group,
+    .rds-toggle-button.is-wrap.rds-toggle-button--spaced .rds-toggle-button__custom-group {
+      flex-wrap: wrap;
+    }
+  }
+}

--- a/raaghu-elements/rds-toggle-button/rds-toggle-button.scss
+++ b/raaghu-elements/rds-toggle-button/rds-toggle-button.scss
@@ -143,7 +143,7 @@
 
 // Small mobile responsiveness (prevents horizontal scrollbar at <= 400px width)
 @media (max-width: 400px) {
-  .rds-toggle-button { width: 100%; max-width:100%; }
+  .rds-toggle-button { width: 100%; max-width:100%; overflow-x:hidden; }
 
   .rds-toggle-button__group,
   .rds-toggle-button--spaced .rds-toggle-button__custom-group {
@@ -165,7 +165,27 @@
   .rds-toggle-button__icon { margin-right: 4px !important; }
 
   // Spaced variant: remove horizontal margins that create overflow
-  .rds-toggle-button--spaced .rds-toggle-button__button-wrapper { margin-left: 0 !important; }
+  .rds-toggle-button--spaced .rds-toggle-button__button-wrapper { 
+    margin-left: 0 !important; 
+  }
+
+  // Spaced + horizontal: prevent each wrapper from forcing 100% width (causes scroll)
+  .rds-toggle-button--spaced:not(.rds-toggle-button--vertical) .rds-toggle-button__button-wrapper { 
+    width:auto; 
+    flex:1 1 50%; // two per row pattern for readability
+    min-width:50%;
+    max-width:50%;
+  }
+  .rds-toggle-button--spaced:not(.rds-toggle-button--vertical) .rds-toggle-button__button-wrapper .rds-toggle-button__button { 
+    flex:1 1 auto; 
+    width:100%;
+    max-width:100%;
+    min-width:0; 
+    padding:6px 8px; // restore a bit of horizontal spacing to prevent overlap
+    box-sizing:border-box;
+  }
+  // Ensure flex chain doesn't create min-content overflow
+  .rds-toggle-button--spaced .rds-toggle-button__custom-group { min-width:0; flex-wrap:wrap; }
 
   // Fallback: if still overflowing for edge locales, allow wrap cleanly
   @supports (flex-wrap: wrap) {

--- a/raaghu-elements/rds-toggle-button/rds-toggle-button.stories.tsx
+++ b/raaghu-elements/rds-toggle-button/rds-toggle-button.stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof RdsToggleButton> = {
     size: {
       control: { type: 'select' },
       options: ['small', 'medium', 'large'],
-      description: 'Sets the size of the toggle buttons.',
+      description: 'Sets the size of the toggle buttons (overrides inputSize).',
     },
     color: {
       control: { type: 'select' },

--- a/raaghu-elements/rds-toggle-button/rds-toggle-button.tsx
+++ b/raaghu-elements/rds-toggle-button/rds-toggle-button.tsx
@@ -30,7 +30,8 @@ const RdsToggleButton: React.FC<RdsToggleButtonProps> = ({
   onChange,
   value: controlledValue,
   defaultValue,
-  inputSize = 'small',
+  inputSize = 'small', // legacy prop name
+  size: sizeProp, // MUI size prop / Storybook control
   ...props
 }) => {
   const [internalValue, setInternalValue] = useState<string | string[]>(() => {
@@ -63,19 +64,19 @@ const RdsToggleButton: React.FC<RdsToggleButtonProps> = ({
   }, [enforceSelected, options, multiple, internalValue, isControlled]);
 
   // Map inputSize to BEM modifier class
+  // Allow both `size` (storybook / MUI) and legacy `inputSize`. `size` wins.
+  const effectiveSize = (sizeProp as 'small' | 'medium' | 'large' | undefined) || inputSize;
+
   const sizeClass =
-    inputSize === 'large'
+    effectiveSize === 'large'
       ? 'rds-toggle-button--large'
-      : inputSize === 'medium'
+      : effectiveSize === 'medium'
       ? 'rds-toggle-button--medium'
       : 'rds-toggle-button--small';
 
   // Large size style override using design tokens
-  const largeButtonStyle = inputSize === 'large' ? {
-    fontSize: 'var(--rds-font-size-lg)',
-    padding: 'var(--rds-spacing-lg, 12px) var(--rds-spacing-2xl)',
-    minHeight: 'var(--rds-toggle-button-min-height-lg)'
-  } : {};
+  // (Legacy) Inline style for large retained for backward compat; CSS now handles size classes.
+  const largeButtonStyle = effectiveSize === 'large' ? {} : {};
 
 
   // Handle change with enforcement that at least one option must be selected
@@ -148,7 +149,8 @@ const RdsToggleButton: React.FC<RdsToggleButtonProps> = ({
           value={option.value}
           disabled={option.disabled}
           className={`rds-toggle-button__button ${sizeClass}`}
-          style={inputSize === 'large' ? largeButtonStyle : {}}
+          size={effectiveSize}
+          style={largeButtonStyle}
           aria-pressed={multiple ? 
             Array.isArray(value) && value.includes(option.value) : 
             value === option.value
@@ -196,7 +198,8 @@ const RdsToggleButton: React.FC<RdsToggleButtonProps> = ({
             value={option.value}
             disabled={option.disabled}
             className={getButtonClassName(index) + ' ' + sizeClass}
-            style={inputSize === 'large' ? largeButtonStyle : {}}
+            size={effectiveSize}
+            style={largeButtonStyle}
             onClick={(e) => handleCustomButtonClick(e, option.value)}
             selected={isSelected}
             aria-pressed={isSelected}
@@ -219,9 +222,11 @@ const RdsToggleButton: React.FC<RdsToggleButtonProps> = ({
   // Determine if we need to use custom spacing rendering
   const useCustomSpacing = spacing > 0;
 
+  const countClass = effectiveSize === 'large' && options.length === 3 ? 'rds-toggle-button--large-three' : '';
+
   return (
     <div
-  className={`rds-toggle-button rds-toggle-button--${orientation} ${sizeClass} ${useCustomSpacing ? 'rds-toggle-button--spaced' : ''} ${options.length > 3 ? 'rds-toggle-button--wrap-mobile' : ''}`}
+  className={`rds-toggle-button rds-toggle-button--${orientation} ${sizeClass} ${countClass} ${useCustomSpacing ? 'rds-toggle-button--spaced' : ''} ${options.length > 3 ? 'rds-toggle-button--wrap-mobile' : ''}`}
       role="group"
       aria-label={otherProps['aria-label'] || 'Toggle button group'}
     >
@@ -235,6 +240,7 @@ const RdsToggleButton: React.FC<RdsToggleButtonProps> = ({
           orientation={orientation}
           onChange={handleChange}
           value={value}
+          size={effectiveSize}
           color={color}
           {...otherProps}
           className="rds-toggle-button__group"

--- a/raaghu-elements/rds-toggle-button/rds-toggle-button.tsx
+++ b/raaghu-elements/rds-toggle-button/rds-toggle-button.tsx
@@ -221,7 +221,7 @@ const RdsToggleButton: React.FC<RdsToggleButtonProps> = ({
 
   return (
     <div
-      className={`rds-toggle-button rds-toggle-button--${orientation} ${sizeClass} ${useCustomSpacing ? 'rds-toggle-button--spaced' : ''}`}
+  className={`rds-toggle-button rds-toggle-button--${orientation} ${sizeClass} ${useCustomSpacing ? 'rds-toggle-button--spaced' : ''} ${options.length > 3 ? 'rds-toggle-button--wrap-mobile' : ''}`}
       role="group"
       aria-label={otherProps['aria-label'] || 'Toggle button group'}
     >


### PR DESCRIPTION
## Description

> Apart from without icons, vertical buttons and standalone toggle buttons these stories other stories are not looking good in small mobile size.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6eb1705b-04e6-4a9e-829e-6a933e973833" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/755f17df-c1a3-4f7d-8faa-6bb40bb81ba6" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/26945645-be24-4b15-84ea-9f4486a94ca5" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2bc3dd14-0d19-4d7b-bca7-248ab66dc5ec" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b5c9145d-ee2f-42c0-94ef-48743385f802" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ab866814-ef01-4224-947b-246981f00aaf" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/defe50e8-9c95-4c5d-a8d2-e448c8ad8300" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/210657d0-f904-4996-b7d7-008645ffb737" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9a2197ab-7e36-48bb-b3d3-f17dfa5fcacd" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9cd0fdd1-9a7c-44e2-80e3-47680fc1967c" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0b052216-d5c7-4def-b0cf-2207b613cc9e" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/012f4638-9256-463d-8a03-2141aacccc96" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/611b6a3f-e85a-4c87-8720-d305388a04b5" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/717f8dbd-b047-44ef-96a0-283acd0ad979" />
