### PR TITLE
Resolved Bug 2705 : Code Snippet Dark Theme Not Show Proper

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-quill": "^2.0.0",
     "react-router-dom": "^7.8.1",
     "react-svg-worldmap": "^2.0.0-alpha.16",
+    "react-syntax-highlighter": "^15.5.0",
     "slate": "^0.118.0",
     "slate-history": "^0.113.1",
     "slate-react": "^0.117.4",

--- a/raaghu-components/rds-comp-code-snippet/rds-comp-code-snippet.scss
+++ b/raaghu-components/rds-comp-code-snippet/rds-comp-code-snippet.scss
@@ -57,6 +57,30 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    // Ensure any rendered pre/code from syntax highlighter stays inline and doesn't break layout
+    pre,
+    code,
+    span {
+      display: inline !important;
+      white-space: nowrap !important;
+      overflow: hidden !important;
+      text-overflow: ellipsis !important;
+      vertical-align: middle;
+    }
+  }
+
+  // Inline highlighter class used by SyntaxHighlighter for single-line inline rendering
+  &__inline-highlighter {
+    display: inline !important;
+    background: transparent !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    vertical-align: middle !important;
+    font-family: inherit !important;
+    line-height: inherit !important;
   }
 
   // Actions container for single line
@@ -136,6 +160,30 @@
         line-height: 1.5;
       }
     }
+
+    // Target the SyntaxHighlighter wrapper via a class set on the component
+    &__highlighter {
+      background: transparent !important;
+      padding: 16px !important;
+      margin: 0 !important;
+      font-family: inherit !important;
+      line-height: inherit !important;
+
+      // Ensure pre/code produced by the library inherit our styling
+      pre, code {
+        background: transparent !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        font-family: inherit !important;
+        line-height: inherit !important;
+      }
+    }
+  }
+
+  // Modifier when a max height is provided via CSS variable
+  &__content--with-max {
+    max-height: var(--rds-code-max-height, 400px);
+    overflow: auto;
   }
 
   // Code with line numbers wrapper
@@ -365,4 +413,25 @@
       color: var(--rds-syntax-selector-dark, #86efac);
     }
   }
+}
+[data-theme="dark"] {
+  .rds-comp-code-snippet--light {
+    background-color: var(--rds-color-surface-dark, #1f2937);
+    color: var(--rds-color-on-surface-dark, #f9fafb);
+    border-color: var(--rds-color-border-dark, #374151);
+}
+.rds-comp-code-snippet--light code {
+    color: var(--rds-color-on-surface-dark, #f9fafb);
+}
+.rds-comp-code-snippet--light .rds-comp-code-snippet__copy-button {
+    background-color: var(--rds-color-surface-variant-dark, #374151);
+    color: var(--rds-color-on-surface-variant-dark, #d1d5db);
+    border-color: var(--rds-color-border-dark, #4b5563);
+}
+.rds-button {
+    color: var(--btn-primary-solid-default, #3c98ff) !important;
+}
+.rds-comp-code-snippet--light .rds-comp-code-snippet__toolbar::after {
+    background-color: var(--rds-color-border-dark, #374151);
+}
 }

--- a/raaghu-components/rds-comp-code-snippet/rds-comp-code-snippet.tsx
+++ b/raaghu-components/rds-comp-code-snippet/rds-comp-code-snippet.tsx
@@ -2,10 +2,29 @@ import React, { useState } from "react";
 import "./rds-comp-code-snippet.scss";
 import OpenInFullOutlinedIcon from "@mui/icons-material/OpenInFullOutlined";
 import RdsButton from "../../raaghu-elements/rds-button/rds-button";
+// Syntax highlighting
+import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/default-highlight';
+import { atomOneLight } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+// Derive a dark variant from the light style so token colors stay consistent
+const darkStyle = {
+  // copy all token styles from atomOneLight
+  ...atomOneLight as any,
+  hljs: {
+    // keep the same token colors, but use a dark background and lighter default text
+    ...((atomOneLight as any).hljs || {}),
+    background: '#0b1220',
+    color: '#e6eef6',
+  },
+};
+
+// The library's bundled type can be incompatible with the TSX/React Component type
+// in some TypeScript/React versions. Create a typed alias to satisfy JSX usage.
+const Highlighter = SyntaxHighlighter as unknown as React.ComponentType<any>;
 
 export interface RdsCompCodeSnippetProps {
   code: string;
-  language?: boolean;
+  // language can be a string like 'html' or a boolean to indicate showing default label
+  language?: string | boolean;
   codeLines?: boolean;
   theme?: "light" | "dark";
   type?: "singleLine" | "multiLine";
@@ -38,13 +57,28 @@ const RdsCompCodeSnippet: React.FC<RdsCompCodeSnippetProps> = ({
     return code.split("\n");
   };
 
+  // Normalize language handling
+  const showLanguage = !!language;
+  const languageLabel = typeof language === 'string' ? language : 'html';
+  const highlighterStyle = theme === 'dark' ? (darkStyle as any) : (atomOneLight as any);
+
   return (
     <div className={`rds-comp-code-snippet rds-comp-code-snippet--${theme} rds-comp-code-snippet--${type} ${className}`}>
       <div className="rds-comp-code-snippet__container">
         {type === "singleLine" ? (
           <div className="rds-comp-code-snippet__toolbar rds-comp-code-snippet__toolbar--single-line">
-            <span className="rds-comp-code-snippet__single-line-code">
-              {code.length > 100 ? code.slice(0, 100) + "..." : code}
+              <span className="rds-comp-code-snippet__single-line-code">
+              <Highlighter
+                language={languageLabel as string}
+                style={highlighterStyle}
+                showLineNumbers={false}
+                wrapLongLines={false}
+                // render as inline elements to avoid disturbing the toolbar layout
+                PreTag="span"
+                className="rds-comp-code-snippet__inline-highlighter"
+              >
+                {code.length > 100 ? code.slice(0, 100) + '...' : code}
+              </Highlighter>
             </span>
             <div className="rds-comp-code-snippet__actions">
               {language && <span className="rds-comp-code-snippet__language-label">Html</span>}
@@ -95,29 +129,19 @@ const RdsCompCodeSnippet: React.FC<RdsCompCodeSnippetProps> = ({
                 <OpenInFullOutlinedIcon className="rds-comp-code-snippet__expand-icon" />
               </div>
               <div 
-                className="rds-comp-code-snippet__content" 
-                style={maxHeight ? { maxHeight, overflow: "auto" } : {}}
+                className={`rds-comp-code-snippet__content ${maxHeight ? 'rds-comp-code-snippet__content--with-max' : ''}`} 
+                style={maxHeight ? { ['--rds-code-max-height' as any]: maxHeight } : {}}
               >
-                <pre>
-                  <code className={`language-${language}`}>
-                    {codeLines ? (
-                      <div className="rds-comp-code-snippet__code-with-lines">
-                        <div className="rds-comp-code-snippet__line-numbers">
-                          {getLines().map((_, index) => (
-                            <span key={index} className="rds-comp-code-snippet__line-number">{index + 1}</span>
-                          ))}
-                        </div>
-                        <div className="rds-comp-code-snippet__code-lines">
-                          {getLines().map((line, index) => (
-                            <span key={index} className="rds-comp-code-snippet__code-line">{line}</span>
-                          ))}
-                        </div>
-                      </div>
-                    ) : (
-                      code
-                    )}
-                  </code>
-                </pre>
+                <div className="rds-comp-code-snippet__syntax">
+                    <Highlighter
+                      language={languageLabel as string}
+                      style={highlighterStyle}
+                      showLineNumbers={codeLines}
+                      className="rds-comp-code-snippet__highlighter"
+                    >
+                      {code}
+                    </Highlighter>
+                  </div>
               </div>
               <div className="rds-comp-code-snippet__show-more">
                 <RdsButton color="primary" changeLeftIcon='add' showLeftIcon layout="icon+text" size="small" state="default" style="transparent" text="Show More" />


### PR DESCRIPTION

## Description
> Resolve the Code Snippet dark theme realted issue. 
-  **Code Snippet**

## Screenshots :
 <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6b8adc6c-b8a0-46b1-a0ca-2c781a50d764" />
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes