### PR TITLE
Resolved Bug 2795 : In Collapse  Default & Long Content Story Not Show Proper In Dark Theme

### DIFF
--- a/raaghu-elements/rds-collapse/rds-collapse.scss
+++ b/raaghu-elements/rds-collapse/rds-collapse.scss
@@ -30,3 +30,26 @@
     pointer-events: none;
   }
 }
+
+// Storybook helper styles (used in stories to avoid inline sx)
+.rds-collapse__story-box {
+  padding: var(--rds-spacing-md, 16px);
+  border-radius: var(--rds-border-radius-sm, 4px);
+  background-color: var(--rds-color-surface-light, #f5f5f5);
+}
+
+.rds-collapse__story-box--warning {
+  background-color: var(--rds-color-warning-light, #ffeb3b);
+}
+
+[data-theme=dark]
+{ 
+  .rds-collapse__story-box {
+    background-color: var(--rds-color-background, #545454) !important;
+    color: var(--rds-color-on-surface-dark, #ffffff) !important;
+  }
+  .rds-collapse__story-box--warning {
+    background-color: var(--rds-color-warning-light, #e6de94) !important;
+    color: #000000 !important; // explicit black text in dark theme per request
+  }
+}

--- a/raaghu-elements/rds-collapse/rds-collapse.stories.tsx
+++ b/raaghu-elements/rds-collapse/rds-collapse.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Typography, Box } from '@mui/material';
 import RdsCollapse from './rds-collapse';
+import RdsTypography from '../../raaghu-elements/rds-typography/rds-typography';
 
 const meta: Meta<typeof RdsCollapse> = {
   title: 'Elements/Collapse',
@@ -30,13 +31,13 @@ export const Default: Story = {
     title: 'Collapsible Section',
     expanded: false,
     children: (
-      <Box sx={{ p: 2, backgroundColor: 'grey.100', borderRadius: 1 }}>
-        <Typography variant="body1" paragraph>
+      <Box className="rds-collapse__story-box">
+        <RdsTypography variant="body1" paragraph>
           This is the content that can be collapsed and expanded.
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
+        </RdsTypography>
+        <RdsTypography variant="body2" color="text.secondary">
           You can put any content here including text, images, forms, or other components.
-        </Typography>
+        </RdsTypography>
       </Box>
     ),
   },
@@ -48,12 +49,12 @@ export const Expanded: Story = {
     expanded: true,
     children: (
       <Box sx={{ p: 2, backgroundColor: 'primary.light', color: 'primary.contrastText', borderRadius: 1 }}>
-        <Typography variant="body1" paragraph>
+        <RdsTypography variant="body1" paragraph>
           This collapse component starts in an expanded state.
-        </Typography>
-        <Typography variant="body2">
+        </RdsTypography>
+        <RdsTypography variant="body2">
           Click the arrow button to collapse this content.
-        </Typography>
+        </RdsTypography>
       </Box>
     ),
   },
@@ -65,12 +66,12 @@ export const NoTitle: Story = {
     showToggleButton: true,
     children: (
       <Box sx={{ p: 2, backgroundColor: 'secondary.light', color: 'secondary.contrastText', borderRadius: 1 }}>
-        <Typography variant="h6" gutterBottom>
+        <RdsTypography variant="h6" gutterBottom>
           Content without title
-        </Typography>
-        <Typography variant="body2">
+        </RdsTypography>
+        <RdsTypography variant="body2">
           This collapse component has no title, just a toggle button.
-        </Typography>
+        </RdsTypography>
       </Box>
     ),
   },
@@ -83,9 +84,9 @@ export const NoToggleButton: Story = {
     showToggleButton: false,
     children: (
       <Box sx={{ p: 2, backgroundColor: 'success.light', color: 'success.contrastText', borderRadius: 1 }}>
-        <Typography variant="body1">
+        <RdsTypography variant="body1">
           This collapse component has no toggle button and is controlled externally.
-        </Typography>
+        </RdsTypography>
       </Box>
     ),
   },
@@ -96,19 +97,19 @@ export const LongContent: Story = {
     title: 'Long Content Example',
     expanded: false,
     children: (
-      <Box sx={{ p: 2, backgroundColor: 'warning.light', borderRadius: 1 }}>
-        <Typography variant="h6" gutterBottom>
+  <Box className="rds-collapse__story-box rds-collapse__story-box--warning">
+        <RdsTypography variant="h6" gutterBottom>
           Lorem Ipsum
-        </Typography>
-        <Typography variant="body2" paragraph>
+        </RdsTypography>
+        <RdsTypography variant="body2" paragraph>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-        </Typography>
-        <Typography variant="body2" paragraph>
+        </RdsTypography>
+        <RdsTypography variant="body2" paragraph>
           Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        </Typography>
-        <Typography variant="body2">
+        </RdsTypography>
+        <RdsTypography variant="body2">
           Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
-        </Typography>
+        </RdsTypography>
       </Box>
     ),
   },

--- a/raaghu-elements/rds-collapse/rds-collapse.tsx
+++ b/raaghu-elements/rds-collapse/rds-collapse.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Collapse as MuiCollapse, CollapseProps, Box, Typography, IconButton } from '@mui/material';
+import './rds-collapse.scss';
 import { ExpandMore } from '@mui/icons-material';
 
 export interface RdsCollapseProps extends Omit<CollapseProps, 'children' | 'onToggle'> {


### PR DESCRIPTION

## Description
> Resolve the issues in Collapse Default & Long content story dark theme is not display proper
-  **Collapse**

## Screenshots :
 <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1cebdb6a-c273-4056-8cde-d1a0a7fee6b3" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/80cdd0bb-32a3-4c72-9141-340aa74da717" />
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes