### PR TITLE
Resolved Bug 2796 : Design System > Elements > Breadcrumbs > Default & simple stories icon style is different.

### DIFF
--- a/raaghu-elements/rds-breadcrumbs/rds-breadcrumbs.scss
+++ b/raaghu-elements/rds-breadcrumbs/rds-breadcrumbs.scss
@@ -27,7 +27,7 @@
     display: flex;
     align-items: center;
     font-size: var(--rds-font-size-sm, 16px);
-    color: var(--rds-color-text-secondary, #666);
+    color: var(--rds-color-text-secondary);
     user-select: none;
   }
 

--- a/raaghu-elements/rds-breadcrumbs/rds-breadcrumbs.stories.tsx
+++ b/raaghu-elements/rds-breadcrumbs/rds-breadcrumbs.stories.tsx
@@ -96,6 +96,7 @@ export const Simple: Story = {
     showIcon: false,
     state: 'default',
     level: 'level2',
+    separatorType: BreadcrumbSeparator.GreaterThan,
   },
 };
 


### PR DESCRIPTION
## Description
> Resolve the issues on Element: 
- Breadcrumbs:
  - Default & simple stories icon style is different.
  - Dark theme icon is not display proper.
  
## Screenshots :
 
<img width="1920" height="991" alt="image" src="https://github.com/user-attachments/assets/32e98c95-a9e3-4ffd-a873-4a57e996b668" />
<img width="1920" height="984" alt="image" src="https://github.com/user-attachments/assets/34dc3a99-192f-4158-97b0-8c3b059238bb" />
<img width="1920" height="983" alt="image" src="https://github.com/user-attachments/assets/02adde3d-abf4-427b-8f61-8496b825ddfd" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
