### PR TITLE
Resolved Bug 2632 & 2704 : Resolve Popover & Chat Issues

### DIFF
--- a/raaghu-components/rds-comp-chat/rds-comp-chat.scss
+++ b/raaghu-components/rds-comp-chat/rds-comp-chat.scss
@@ -864,6 +864,14 @@
   }
 }
 
+.rds-comp-chat__screen-main .rds-comp-chat__user-item:hover, .rds-comp-chat__screen-main .chat-screen-main .user-item:hover, .chat-screen-main .rds-comp-chat__screen-main .user-item:hover {
+.rds-avatar {
+  &__name, &__designation {
+    color: var(--rds-color-on-primary, #000) !important;
+  }
+}
+}
+
 // Legacy class support (for backward compatibility during transition)
 .chat-container {
   @extend .rds-comp-chat;

--- a/raaghu-components/rds-comp-code-snippet/rds-comp-code-snippet.scss
+++ b/raaghu-components/rds-comp-code-snippet/rds-comp-code-snippet.scss
@@ -429,7 +429,7 @@
     border-color: var(--rds-color-border-dark, #4b5563);
 }
 .rds-button {
-    color: var(--btn-primary-solid-default, #3c98ff) !important;
+    color: var(--btn-primary-solid-default) !important;
 }
 .rds-comp-code-snippet--light .rds-comp-code-snippet__toolbar::after {
     background-color: var(--rds-color-border-dark, #374151);

--- a/raaghu-elements/rds-popover/rds-popover.stories.tsx
+++ b/raaghu-elements/rds-popover/rds-popover.stories.tsx
@@ -12,15 +12,6 @@ const meta: Meta<typeof RdsPopover> = {
   },
   tags: ['autodocs'],
   argTypes: {
-    width: {
-      control: 'text',
-    },
-    maxWidth: {
-      control: 'text',
-    },
-    showCloseButton: {
-      control: 'boolean',
-    },
     position: {
       control: 'select',
       options: ['top-left', 'top-center', 'top-right', 'right-top', 'right-center', 'right-bottom', 'bottom-right', 'bottom-center', 'bottom-left', 'left-bottom', 'left-center', 'left-top', 'no-arrow'],


### PR DESCRIPTION
## Description
> Resolve the issues on : 
-  **Popover**
-  **Chat**
> Remove unwanted controls on with list in Popover.
> Resolve issue hover on the chat member it's not looking proper in dark mode.
> Resolve plus icon is not visible in dark mode.

## Screenshots :
 
<img width="1915" height="967" alt="image" src="https://github.com/user-attachments/assets/4b7b791a-f06a-4d0e-804d-b14a7f993a40" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes