### PR TITLE
Resolved Bug 2834 : In Kanban Board Dropdown Tag Label Overlapping Or Hide With Menu

### DIFF
--- a/raaghu-components/rds-comp-kanban-board/rds-comp-kanban-board.tsx
+++ b/raaghu-components/rds-comp-kanban-board/rds-comp-kanban-board.tsx
@@ -188,6 +188,15 @@ const RdsCompKanbanBoard = (props: RdsCompKanbanBoardProps) => {
                                       <Paper {...props} className="rds-kanban-board__autocomplete-paper"
                                       />
                                     )}
+                                    // Ensure the popper doesn't clip long labels and appears above other elements
+                                    slotProps={{
+                                      popper: {
+                                        modifiers: [
+                                          { name: 'preventOverflow', options: { altBoundary: true, rootBoundary: 'viewport' } },
+                                          { name: 'offset', options: { offset: [0, 10] } }
+                                        ],
+                                      }
+                                    }}
                                   />
                                   <Box className="add-item-btn btn-margin add-board rds-kanban-board__button-container">
                                     <Button variant="outlined" size="medium" startIcon={PlusIcon} onClick={() => onAddSubCardClick(index)} className="rds-kanban-board__add-button">Add Item</Button>


### PR DESCRIPTION
## Description
> Resolve the issues In Kanban Board Dropdown Tag Label Overlapping Or Hide With Menu.
-  **Kanban Board**

## Screenshots :
 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/044808bd-25e9-4743-a8b5-db1b244da50e" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes