### PR TITLE
Resolved Bug 2849 : Design System > Element > Fix dropdown overflowing in documentation

### DIFF
--- a/raaghu-elements/rds-autocomplete/rds-autocomplete.stories.tsx
+++ b/raaghu-elements/rds-autocomplete/rds-autocomplete.stories.tsx
@@ -126,6 +126,11 @@ export const Default: Story = {
     popupIcon: <PopupIcon />,
   },
 };
+Default.parameters = { 
+  controls: { 
+    include: ['options', 'label', 'isMandatory', 'placeholder', 'showHintText', 'selectSize', 'helperText', 'controlStyle', 'isShowCheckbox', 'isShowRadio', 'isShowUser', 'variant', 'error', 'disabled', 'showTitle', 'state'] 
+  } 
+};
 
 export const Disabled: Story = {
   args: {
@@ -140,6 +145,11 @@ export const Disabled: Story = {
     userIcon: <UserIcon />,
     popupIcon: <PopupIcon />,
   },
+};
+Disabled.parameters = { 
+  controls: { 
+    include: ['options', 'label', 'isMandatory', 'placeholder', 'disabled', 'isShowCheckbox', 'isShowRadio', 'isShowUser', 'variant', 'selectSize'] 
+  } 
 };
 
 export const Error: Story = {
@@ -157,6 +167,11 @@ export const Error: Story = {
     popupIcon: <PopupIcon />,
   },
 };
+Error.parameters = { 
+  controls: { 
+    include: ['options', 'label', 'isMandatory', 'placeholder', 'error', 'helperText', 'isShowCheckbox', 'isShowRadio', 'isShowUser', 'variant', 'selectSize', 'showHintText'] 
+  } 
+};
 
 export const Filled: Story = {
   args: {
@@ -171,6 +186,11 @@ export const Filled: Story = {
     userIcon: <UserIcon />,
     popupIcon: <PopupIcon />,
   },
+};
+Filled.parameters = { 
+  controls: { 
+    include: ['options', 'label', 'isMandatory', 'placeholder', 'variant', 'isShowCheckbox', 'isShowRadio', 'isShowUser', 'selectSize'] 
+  } 
 };
 
 export const Standard: Story = {
@@ -187,6 +207,11 @@ export const Standard: Story = {
     popupIcon: <PopupIcon />,
   },
 };
+Standard.parameters = { 
+  controls: { 
+    include: ['options', 'label', 'isMandatory', 'placeholder', 'variant', 'isShowCheckbox', 'isShowRadio', 'isShowUser', 'selectSize'] 
+  } 
+};
 
 export const WithHelperText: Story = {
   args: {
@@ -202,4 +227,9 @@ export const WithHelperText: Story = {
     userIcon: <UserIcon />,
     popupIcon: <PopupIcon />,
   },
+};
+WithHelperText.parameters = { 
+  controls: { 
+    include: ['options', 'label', 'isMandatory', 'placeholder', 'variant', 'isShowCheckbox', 'isShowRadio', 'isShowUser', 'selectSize'] 
+  } 
 };

--- a/raaghu-elements/rds-card/rds-card.stories.tsx
+++ b/raaghu-elements/rds-card/rds-card.stories.tsx
@@ -118,6 +118,11 @@ export const Default: Story = {
     ),
   },
 };
+Default.parameters = { 
+  controls: { 
+    include: ['state', 'style', 'showIndicator', 'showTitle', 'showSubtext', 'showDescription', 'layout', 'showIcon', 'changeIcon', 'title', 'cardSubtext', 'description', 'children', 'variant', 'padding'] 
+  } 
+};
 
 export const Elevated: Story = {
   args: {
@@ -134,6 +139,11 @@ export const Elevated: Story = {
     ),
   },
 };
+Elevated.parameters = { 
+  controls: { 
+    include: ['state', 'style', 'showIndicator', 'showTitle', 'showSubtext', 'showDescription', 'layout', 'showIcon', 'changeIcon', 'title', 'cardSubtext', 'description', 'children', 'variant', 'padding'] 
+  } 
+};
 
 export const Outlined: Story = {
   args: {
@@ -149,6 +159,11 @@ export const Outlined: Story = {
       </CardContent>
     ),
   },
+};
+Outlined.parameters = { 
+  controls: { 
+    include: ['state', 'style', 'showIndicator', 'showTitle', 'showSubtext', 'showDescription', 'layout', 'showIcon', 'changeIcon', 'title', 'cardSubtext', 'description', 'children', 'variant', 'padding']  
+  } 
 };
 
 export const WithActions: Story = {
@@ -170,6 +185,11 @@ export const WithActions: Story = {
       </>
     ),
   },
+};
+WithActions.parameters = { 
+  controls: { 
+    include: ['state', 'style', 'showIndicator', 'showTitle', 'showSubtext', 'showDescription', 'layout', 'showIcon', 'changeIcon', 'title', 'cardSubtext', 'description', 'children', 'variant', 'padding'] 
+  } 
 };
 export const WithAvatar: Story = {
   args: {
@@ -332,6 +352,11 @@ export const WithAvatar: Story = {
     );
   },
 };
+WithAvatar.parameters = { 
+  controls: { 
+    include: ['state', 'style', 'showIndicator', 'showTitle', 'showSubtext', 'showDescription', 'layout', 'showIcon', 'changeIcon', 'title', 'cardSubtext', 'description', 'children', 'variant', 'padding']  
+  } 
+};
 
 export const WithBadges: Story = {
   args: {
@@ -365,6 +390,11 @@ export const WithBadges: Story = {
       </div>
     ),
   },
+};
+WithBadges.parameters = { 
+  controls: { 
+    include: ['state', 'style', 'showIndicator', 'showTitle', 'showSubtext', 'showDescription', 'layout', 'showIcon', 'changeIcon', 'title', 'cardSubtext', 'description', 'children', 'variant', 'padding'] 
+  } 
 };
 
 export const WithButton: Story = {
@@ -401,6 +431,10 @@ export const WithButton: Story = {
     ),
   },
 };
+WithButton.parameters = { 
+  controls: { 
+    include: ['state', 'style', 'showIndicator', 'showTitle', 'showSubtext', 'showDescription', 'layout', 'showIcon', 'changeIcon', 'title', 'cardSubtext', 'description', 'children', 'variant', 'padding']   } 
+};
 
 export const WithCustomPadding: Story = {
   args: {
@@ -411,6 +445,11 @@ export const WithCustomPadding: Story = {
       </Typography>
     ),
   },
+};
+WithCustomPadding.parameters = { 
+  controls: { 
+    include: ['state', 'style', 'showIndicator', 'showTitle', 'showSubtext', 'showDescription', 'layout', 'showIcon', 'changeIcon', 'title', 'cardSubtext', 'description', 'children', 'variant', 'padding']  
+  } 
 };
 
 export const WithImage: Story = {
@@ -464,6 +503,11 @@ export const WithImage: Story = {
     ),
   },
 };
+WithImage.parameters = { 
+  controls: { 
+    include: ['state', 'style', 'showIndicator', 'showTitle', 'showSubtext', 'showDescription', 'layout', 'showIcon', 'changeIcon', 'title', 'cardSubtext', 'description', 'children', 'variant', 'padding'] 
+  } 
+};
 
 export const WithLinkButton: Story = {
   args: {
@@ -488,6 +532,11 @@ export const WithLinkButton: Story = {
       />
     ),
   },
+};
+WithLinkButton.parameters = { 
+  controls: { 
+    include: ['state', 'style', 'showIndicator', 'showTitle', 'showSubtext', 'showDescription', 'layout', 'showIcon', 'changeIcon', 'title', 'cardSubtext', 'description', 'children', 'variant', 'padding'] 
+  } 
 };
 
 export const WithTags: Story = {
@@ -523,4 +572,9 @@ export const WithTags: Story = {
       </>
     ),
   },
+};
+WithTags.parameters = { 
+  controls: { 
+    include: ['state', 'style', 'showIndicator', 'showTitle', 'showSubtext', 'showDescription', 'layout', 'showIcon', 'changeIcon', 'title', 'cardSubtext', 'description', 'children', 'variant', 'padding'] 
+  } 
 };

--- a/raaghu-elements/rds-tooltip/rds-tooltip.stories.tsx
+++ b/raaghu-elements/rds-tooltip/rds-tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta } from '@storybook/react-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import RdsTooltip from './rds-tooltip';
 import { Button, IconButton } from '@mui/material';
 import {Delete, Help } from '@mui/icons-material';
@@ -41,8 +41,9 @@ const meta: Meta<typeof RdsTooltip> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof meta>;
 
-export const Default = {
+export const Default: Story = {
   args: {
     label: 'This is a tooltip',
     children:<RdsButton
@@ -61,8 +62,13 @@ export const Default = {
     wrapper: true,
   },
 };
+Default.parameters = { 
+  controls: { 
+    include: ['label', 'style', 'arrow', 'wrapper'] 
+  } 
+};
 
-export const OnIconButton = {
+export const OnIconButton: Story = {
   args: {
     label: 'Delete item',
     children:<RdsButton
@@ -82,8 +88,13 @@ export const OnIconButton = {
     wrapper: true,
   },
 };
+OnIconButton.parameters = { 
+  controls: { 
+    include: ['label', 'style', 'arrow', 'wrapper'] 
+  } 
+};
 
-export const WithArrow = {
+export const WithArrow: Story = {
   args: {
     label: 'Tooltip with arrow',
     arrow: true,
@@ -102,8 +113,13 @@ export const WithArrow = {
     wrapper: true,
   },
 };
+WithArrow.parameters = { 
+  controls: { 
+    include: ['label', 'style', 'arrow', 'wrapper'] 
+  } 
+};
 
-export const Different_Placements = {
+export const Different_Placements: Story = {
   args: {
     label: 'Top placement',
     style: 'top',
@@ -121,8 +137,13 @@ export const Different_Placements = {
     wrapper: true
   },
 };
+Different_Placements.parameters = { 
+  controls: { 
+    include: ['label', 'style', 'arrow', 'wrapper'] 
+  } 
+};
 
-export const LongText = {
+export const LongText: Story = {
   args: {
     label: 'This is a very long tooltip text that might wrap to multiple lines depending on the screen size',
     children:<RdsButton
@@ -141,4 +162,9 @@ export const LongText = {
     style: 'top',
     wrapper: true
   },
+};
+LongText.parameters = { 
+  controls: { 
+    include: ['label', 'style', 'arrow', 'wrapper'] 
+  } 
 };


### PR DESCRIPTION
## Description
> Resolve the issues on Element : 
-  **Autocomplete**
-  **Card**
-  **Tooltip**
> Resolve issue in documentation, the control content extends beyond the screen boundaries.
> Add the property to display required controls to particular stories.

## Screenshots :
 
<img width="1912" height="985" alt="image" src="https://github.com/user-attachments/assets/0a996308-e36c-4cbe-b47f-8ac6f743f42f" />

<img width="1912" height="971" alt="image" src="https://github.com/user-attachments/assets/a2077c10-8a88-45e7-917e-754bd98adfab" />

<img width="1893" height="978" alt="image" src="https://github.com/user-attachments/assets/7eb6921c-be75-455d-ba17-f5caace11729" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes