### PR TITLE
Resolved Bug 2848 : In Accordian State Control Not Working Some Stories

### DIFF
--- a/raaghu-elements/rds-accordion/rds-accordion.scss
+++ b/raaghu-elements/rds-accordion/rds-accordion.scss
@@ -21,7 +21,17 @@
   .rds-accordion__details .MuiAccordionDetails-root .MuiTypography-root { color: #E1E6EB !important; }
   .rds-accordion__title { color: #E1E6EB !important; }
   .rds-accordion .MuiAccordionSummary-expandIconWrapper { color: #B0B3B8 !important; }
-  .rds-accordion--expanded { .MuiCollapse-root .MuiCollapse-wrapper .MuiCollapse-wrapperInner { background-color: #000000 !important; } }
+  .rds-accordion--expanded { 
+    .MuiCollapse-root .MuiCollapse-wrapper .MuiCollapse-wrapperInner { background-color: #000000 !important; }
+    &.rds-accordion--hover .MuiCollapse-root .MuiCollapse-wrapper .MuiCollapse-wrapperInner { background-color: #f3e8ff !important; }
+    &.rds-accordion--selected .MuiCollapse-root .MuiCollapse-wrapper .MuiCollapse-wrapperInner { background-color: #f3e8ff !important; }
+  }
+  // Dark theme selected header styling
+  .rds-accordion.rds-accordion--selected {
+    .rds-accordion__summary { background-color: #f3e8ff !important; }
+    .rds-accordion__title { color: #a259ff !important; font-weight: 600 !important; }
+    .rds-accordion__icon, .MuiAccordionSummary-expandIconWrapper { color: #a259ff !important; }
+  }
 }
 .rds-accordion__container {
   border: 1px solid #7D7D7D;
@@ -225,6 +235,20 @@
   &--expanded {
     .MuiAccordionSummary-expandIconWrapper {
       transform: rotate(180deg) !important;
+    }
+
+    // When also hovered (via actual hover or forced hover class) change inner collapse background
+    &.rds-accordion--hover {
+      .MuiCollapse-root .MuiCollapse-wrapper .MuiCollapse-wrapperInner {
+        background-color: #f3e8ff  !important;
+      }
+    }
+
+    // When selected, apply the same dark background color user requested earlier (#483b3b)
+    &.rds-accordion--selected {
+      .MuiCollapse-root .MuiCollapse-wrapper .MuiCollapse-wrapperInner {
+        background-color: #f3e8ff !important;
+      }
     }
   }
 

--- a/raaghu-elements/rds-accordion/rds-accordion.stories.tsx
+++ b/raaghu-elements/rds-accordion/rds-accordion.stories.tsx
@@ -151,6 +151,7 @@ export const CustomIcon: Story = {
     defaultExpanded: false,
     accordionStyle: 'bottomline',
     ShowLeftIcon: true,
+    state: 'default',
     changeleftIcon: null,
     children: (
       <RdsTypography color="text.secondary">
@@ -158,7 +159,7 @@ export const CustomIcon: Story = {
       </RdsTypography>
     ),
   },
-  render: ({ title, icon, size, defaultExpanded, accordionStyle, ShowLeftIcon, changeleftIcon, children, disabled }) => {
+  render: ({ title, icon, size, defaultExpanded, accordionStyle, ShowLeftIcon, changeleftIcon, children, disabled, state }) => {
     const [expanded, setExpanded] = useState(defaultExpanded);
 
     React.useEffect(() => {
@@ -173,6 +174,7 @@ export const CustomIcon: Story = {
         disabled={disabled}
         accordionStyle={accordionStyle}
         ShowLeftIcon={ShowLeftIcon}
+        state={state}
         expanded={expanded}
         onChange={(_, isExpanded) => setExpanded(isExpanded)}
         changeleftIcon={changeleftIcon}
@@ -190,6 +192,7 @@ export const Disabled: Story = {
     defaultExpanded: false,
     accordionStyle: 'border',
     ShowLeftIcon: true,
+    state: 'default',
     changeleftIcon: null,
     children: (
       <RdsTypography color="text.secondary">
@@ -197,7 +200,7 @@ export const Disabled: Story = {
       </RdsTypography>
     ),
   },
-  render: ({ title, disabled, size, defaultExpanded, accordionStyle, ShowLeftIcon, changeleftIcon, children }) => {
+  render: ({ title, disabled, size, defaultExpanded, accordionStyle, ShowLeftIcon, changeleftIcon, children, state }) => {
     const [expanded, setExpanded] = useState(defaultExpanded);
 
     React.useEffect(() => {
@@ -211,6 +214,7 @@ export const Disabled: Story = {
         accordionStyle={accordionStyle}
         ShowLeftIcon={ShowLeftIcon}
         disabled={disabled}
+        state={state}
         expanded={expanded}
         onChange={(_, isExpanded) => setExpanded(isExpanded)}
         changeleftIcon={changeleftIcon}
@@ -227,6 +231,7 @@ export const Expanded: Story = {
     defaultExpanded: true,
     accordionStyle: 'border',
     ShowLeftIcon: true,
+    state: 'default',
     changeleftIcon: null,
     children: (
       <RdsTypography color="text.secondary">
@@ -234,7 +239,7 @@ export const Expanded: Story = {
       </RdsTypography>
     ),
   },
-  render: ({ title, size, defaultExpanded, accordionStyle, ShowLeftIcon, changeleftIcon, children, disabled }) => {
+  render: ({ title, size, defaultExpanded, accordionStyle, ShowLeftIcon, changeleftIcon, children, disabled, state }) => {
     const [expanded, setExpanded] = useState(defaultExpanded);
 
     React.useEffect(() => {
@@ -248,6 +253,7 @@ export const Expanded: Story = {
         accordionStyle={accordionStyle}
         ShowLeftIcon={ShowLeftIcon}
         disabled={disabled}
+        state={state}
         expanded={expanded}
         onChange={(_, isExpanded) => setExpanded(isExpanded)}
         changeleftIcon={changeleftIcon}
@@ -264,6 +270,7 @@ export const LongContent: Story = {
     defaultExpanded: false,
     accordionStyle: 'border',
     ShowLeftIcon: true,
+    state: 'default',
     changeleftIcon: null,
     children: (
       <RdsTypography color="text.secondary">
@@ -271,7 +278,7 @@ export const LongContent: Story = {
       </RdsTypography>
     ),
   },
-  render: ({ title, size, defaultExpanded, accordionStyle, ShowLeftIcon, changeleftIcon, children, disabled }) => {
+  render: ({ title, size, defaultExpanded, accordionStyle, ShowLeftIcon, changeleftIcon, children, disabled, state }) => {
     const [expanded, setExpanded] = useState(defaultExpanded);
 
     React.useEffect(() => {
@@ -285,6 +292,7 @@ export const LongContent: Story = {
         accordionStyle={accordionStyle}
         ShowLeftIcon={ShowLeftIcon}
         disabled={disabled}
+        state={state}
         expanded={expanded}
         onChange={(_, isExpanded) => setExpanded(isExpanded)}
         changeleftIcon={changeleftIcon}


### PR DESCRIPTION

## Description
> Resolve the issues In Accordian State Control Not Working Some Stories And Dark Theme Issue Resolved
>In the Accordion component, the state control is not functioning for the Custom Icon, Expanded, and Long Content stories. Ensure the state toggling works correctly across these scenarios.
-  **Accordian**

## Screenshots :
 <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0de62b0d-5b0a-4647-a448-0be52c719987" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/890c07fc-fe12-45d8-9ede-869880448e0d" />
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes