### PR TITLE
Resolved Bug 2706: Design System > Dark theme > Color Picker > dark mode it's not looking appropriate.

### DIFF
--- a/raaghu-components/rds-comp-color-picker/rds-comp-color-picker.scss
+++ b/raaghu-components/rds-comp-color-picker/rds-comp-color-picker.scss
@@ -45,7 +45,7 @@
     padding: 6px 10px;
     font-size: 14px;
     transition: all 0.2s ease;
-    color: var(--rds-color-on-surface-variant, #171717);
+    //color: var(--rds-color-on-surface-variant, #171717);
     
     &:focus-visible {
       outline: 2px solid var(--rds-color-primary, #1976d2);
@@ -643,8 +643,10 @@
     background: #000; /* pure black as in reference */
     border: 1px solid rgba(255,255,255,0.22);
     border-radius: 8px;
-    box-shadow: 0 10px 30px rgba(2,6,23,0.6);
-    overflow: hidden;
+   box-shadow: 0 10px 30px rgba(2,6,23,0.6);
+   /* allow dropdowns to escape the container when they are positioned absolutely
+     Use visible overflow so the dropdown isn't clipped in dark theme */
+   overflow: visible;
 
     &::before {
       content: "";
@@ -657,9 +659,23 @@
   }
  
   &__dropdown-menu {
-    background: #000;
+  //  background: #000;
     border: 1px solid rgba(255,255,255,0.22);
     color: var(--rds-color-on-surface);
+    /* Ensure the dropdown floats above other UI and is fully visible */
+    z-index: 9999;
+    /* use a slight elevation so shadows render over adjacent elements */
+   // box-shadow: 0 8px 20px rgba(0,0,0,0.6);
+  }
+
+  /* If the button is near the edge, allow the menu to render outside parent by
+     positioning it fixed instead of absolute when needed. Consumers can toggle
+     a modifier class `--fixed` on the menu when computing placement in JS. */
+  &__dropdown-menu--fixed {
+    position: fixed;
+    top: auto;
+    left: auto;
+    transform: none !important;
   }
 
   /* swatch tiles: subtle light outline so they stand out on black */
@@ -675,6 +691,12 @@
     outline-offset: 2px;
   }
 }
-
-
+ [data-theme="dark"] {
+  .rds-comp-color-picker { 
+    span , .MuiSvgIcon-root{
+    color: #f6f4f4 !important;
+    fill: #efe8e8 !important;
+  }
+  }
+}
 


### PR DESCRIPTION
## Description
> Resolve the issues on Design System > Dark theme > Color Picker > dark mode it's not looking appropriate.
> Make the changes to /rds-comp-color-picker.scss file.
 
## Screenshots:
<img width="1577" height="961" alt="image" src="https://github.com/user-attachments/assets/316726b1-b7b4-49ab-94fb-e4ca4f3c4e20" />

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes