### PR TITLE
Resolved bug 2922: Design System > Elements > Form Control > When select variant control hint text is misaligned.

### DIFF
--- a/raaghu-elements/rds-form-control/rds-form-control.scss
+++ b/raaghu-elements/rds-form-control/rds-form-control.scss
@@ -2,6 +2,10 @@
 .rds-form-control {
   display: block;
   position: relative;
+  
+  &.MuiFormControl-fullWidth {
+    width: 119%;
+  }
 }
 
 .rds-form-control__asterisk {
@@ -19,4 +23,7 @@
 .rds-form-control .MuiFormLabel-root.Mui-focused .MuiFormLabel-asterisk,
 .rds-form-control .MuiFormLabel-root.Mui-error .MuiFormLabel-asterisk {
   color: #d32f2f !important;
+}
+.css-1t6h741-MuiFormHelperText-root{
+  margin-left:0 !important;
 }

--- a/raaghu-elements/rds-form-control/rds-form-control.stories.tsx
+++ b/raaghu-elements/rds-form-control/rds-form-control.stories.tsx
@@ -43,27 +43,39 @@ export const WithTextField: Story = {
   render: (args) => (
     <RdsFormControl {...args}>
       <FormLabel>Email Address</FormLabel>
-      <TextField error={args.error} placeholder="Enter your email" />
+      <TextField
+        error={args.error}
+        placeholder="Enter your email"
+        variant={args.variant}
+        size={args.size}
+        fullWidth={args.fullWidth}
+        disabled={args.disabled}
+      />
       <FormHelperText>We'll never share your email.</FormHelperText>
     </RdsFormControl>
   ),
 };
 
 export const WithSelect: Story = {
-  args: {
-    children: (
-      <>
-        <FormLabel>Country</FormLabel>
-        <Select defaultValue="">
-          <MenuItem value="us">United States</MenuItem>
-          <MenuItem value="ca">Canada</MenuItem>
-          <MenuItem value="uk">United Kingdom</MenuItem>
-          <MenuItem value="de">Germany</MenuItem>
-        </Select>
-        <FormHelperText>Select your country</FormHelperText>
-      </>
-    ),
-  },
+  args: {},
+  render: (args) => (
+    <RdsFormControl {...args}>
+      <FormLabel>Country</FormLabel>
+      <Select
+        defaultValue=""
+        variant={args.variant as any}
+        size={args.size as any}
+        fullWidth={args.fullWidth}
+        disabled={args.disabled}
+      >
+        <MenuItem value="us">United States</MenuItem>
+        <MenuItem value="ca">Canada</MenuItem>
+        <MenuItem value="uk">United Kingdom</MenuItem>
+        <MenuItem value="de">Germany</MenuItem>
+      </Select>
+      <FormHelperText>Select your country</FormHelperText>
+    </RdsFormControl>
+  ),
 };
 
 export const Error: Story = {
@@ -73,7 +85,14 @@ export const Error: Story = {
   render: (args) => (
     <RdsFormControl {...args}>
       <FormLabel>Email Address</FormLabel>
-      <TextField error={args.error} placeholder="Enter your email" />
+      <TextField
+        error={args.error}
+        placeholder="Enter your email"
+        variant={args.variant}
+        size={args.size}
+        fullWidth={args.fullWidth}
+        disabled={args.disabled}
+      />
       <FormHelperText>This field is required.</FormHelperText>
     </RdsFormControl>
   ),
@@ -87,7 +106,14 @@ export const Required: Story = {
   render: (args) => (
     <RdsFormControl {...args}>
       <FormLabel>Email Address</FormLabel>
-      <TextField error={args.error} placeholder="Enter your email" />
+      <TextField
+        error={args.error}
+        placeholder="Enter your email"
+        variant={args.variant}
+        size={args.size}
+        fullWidth={args.fullWidth}
+        disabled={args.disabled}
+      />
       <FormHelperText>This field is required.</FormHelperText>
     </RdsFormControl>
   ),
@@ -101,7 +127,14 @@ export const Disabled: Story = {
   render: (args) => (
     <RdsFormControl {...args}>
       <FormLabel>Email Address</FormLabel>
-      <TextField disabled={args.disabled} error={args.error} placeholder="Enter your email" />
+      <TextField
+        disabled={args.disabled}
+        error={args.error}
+        placeholder="Enter your email"
+        variant={args.variant}
+        size={args.size}
+        fullWidth={args.fullWidth}
+      />
       <FormHelperText>This field is disabled.</FormHelperText>
     </RdsFormControl>
   ),
@@ -115,7 +148,14 @@ export const FullWidth: Story = {
   render: (args) => (
     <RdsFormControl {...args}>
       <FormLabel>Full Width Field</FormLabel>
-      <TextField fullWidth={args.fullWidth} error={args.error} placeholder="This field takes full width" />
+      <TextField
+        fullWidth={args.fullWidth}
+        error={args.error}
+        placeholder="This field takes full width"
+        variant={args.variant}
+        size={args.size}
+        disabled={args.disabled}
+      />
       <FormHelperText>This form control spans the full width.</FormHelperText>
     </RdsFormControl>
   ),
@@ -129,7 +169,14 @@ export const Small: Story = {
   render: (args) => (
     <RdsFormControl {...args}>
       <FormLabel>Small Size</FormLabel>
-      <TextField size={args.size} error={args.error} placeholder="Small sized field" />
+      <TextField
+        size={args.size}
+        error={args.error}
+        placeholder="Small sized field"
+        variant={args.variant}
+        fullWidth={args.fullWidth}
+        disabled={args.disabled}
+      />
       <FormHelperText>This is a small sized form control.</FormHelperText>
     </RdsFormControl>
   ),


### PR DESCRIPTION
## Description
> Resolve the issues on When select variant control hint text is misaligned. 
> fullwidth control is not working.
> Also, variant control is not working properly.
> Make the changes to /rds-form-control.scss. /rds-form-control.stories.tsx file.
 
## Screenshots:
<img width="1920" height="903" alt="image" src="https://github.com/user-attachments/assets/45d4666f-55f7-408a-9483-fa4f89134532" />
<img width="1917" height="935" alt="image" src="https://github.com/user-attachments/assets/d7d2c047-2683-4418-be82-faaf1127e2b0" />
<img width="1897" height="922" alt="image" src="https://github.com/user-attachments/assets/05979a90-7246-45ec-b7f8-eee927b0ce2f" />
<img width="1912" height="948" alt="image" src="https://github.com/user-attachments/assets/93ad78ff-bc43-411b-97c7-9f5391941070" />

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes