### PR TITLE
Resolved Bug 2920 : In File Uploader Reduce Space Between File Uploader & Hint Text

### DIFF
--- a/raaghu-elements/rds-file-uploader/rds-file-uploader.scss
+++ b/raaghu-elements/rds-file-uploader/rds-file-uploader.scss
@@ -226,20 +226,37 @@
     width: 100%;
     box-sizing: border-box;
     display: flex;
-    justify-content: flex-end;
     align-items: center;
     min-height: 20px;
-    margin-top: 4px;
+    margin-top: 4px !important;
+    gap: 8px;
   }
   &__hint {
     font-size: 1rem;
     color: var(--rds-text-secondary, #5c5c5c);
     margin-left: auto;
-    padding-right: 12px;
     align-self: flex-end;
     text-align: right;
     width: auto;
   }
+  &__hint-wrapper {
+    display: flex;
+    flex: 1;
+    justify-content: flex-end;
+    min-width: 0;
+  }
+  &__error-inline {
+    font-size: 0.75rem; // caption size
+    color: var(--rds-color-error, #d32f2f);
+    font-weight: 400;
+    text-align: left;
+    flex-shrink: 0;
+    visibility: hidden;
+    padding-right: 4px;
+    line-height: 1.2;
+    &.is-visible { visibility: visible; }
+  }
+  &__hint.is-hidden { color: transparent; }
   &__browse-btn {
     display: none;
   }

--- a/raaghu-elements/rds-file-uploader/rds-file-uploader.tsx
+++ b/raaghu-elements/rds-file-uploader/rds-file-uploader.tsx
@@ -161,16 +161,22 @@ const RdsFileUploader = ({
             />
           )}
 
-          <Box className="rds-file-uploader__hint-row" sx={{ display: 'flex', justifyContent: 'flex-start', alignItems: 'center', mt: 1.5, minHeight: 20, ml: 0 }}>
+          <Box className="rds-file-uploader__hint-row">
             <Typography
-              className="rds-file-uploader__hint"
               variant="caption"
-              sx={{ color: showHint ? '#353535' : 'transparent', fontWeight: 400, textAlign: 'left', minWidth: 0 }}
+              className={`rds-file-uploader__error-inline ${isMandatory && mandatoryError ? 'is-visible' : ''}`}
             >
-              {showHint ? (hintText || 'Maximum 5MB') : '\u00A0'}
+              {mandatoryError || 'placeholder'}
             </Typography>
+            <div className="rds-file-uploader__hint-wrapper">
+              <Typography
+                className={`rds-file-uploader__hint ${showHint ? '' : 'is-hidden'}`}
+                variant="caption"
+              >
+                {showHint ? (hintText || 'Maximum 5MB') : '\u00A0'}
+              </Typography>
+            </div>
           </Box>
-        
           {showPreview && files.length > 0 && (
             <RdsFileList
               files={files}
@@ -178,12 +184,6 @@ const RdsFileUploader = ({
               removeFile={removeFile}
               formatFileSize={formatFileSize}
             />
-          )}
-
-          {isMandatory && mandatoryError && (
-            <Typography variant="caption" color="error" sx={{ mt: 1 }}>
-              {mandatoryError}
-            </Typography>
           )}
         </Box>
       )}


### PR DESCRIPTION

## Description
> Resolve the issues In File Uploader Reduce Space Between File Uploader & Hint Text
-  **File Uploader**

## Screenshots :
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7d8ac73a-26a1-44d0-954e-4efb20a79dcf" /> 
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes