### PR TITLE
Resolved Bug 2932 : Design System > Elements > Popover > With list stories small mobile when dropdown is open button is hide.

### DIFF
--- a/raaghu-elements/rds-popover/rds-popover.scss
+++ b/raaghu-elements/rds-popover/rds-popover.scss
@@ -231,8 +231,23 @@
   }
 }
 
+
 .MuiButton-containedSuccess, .MuiButton-containedPrimary, .MuiButton-containedSecondary {
   color: #fff !important;
+}
+
+// Custom popover styles for WithList story on small screens
+@media (max-width: 320px) {
+  .with-list-popover .rds-popover__container {
+    max-width: 220px !important;
+    min-width: 120px !important;
+    padding: 6px !important;
+    font-size: 0.95rem;
+  }
+  .with-list-popover .MuiListItem-root {
+    padding-top: 2px !important;
+    padding-bottom: 4px !important;
+  }
 }
 
 @media (max-width: 568px) and (min-width: 320px) {

--- a/raaghu-elements/rds-popover/rds-popover.stories.tsx
+++ b/raaghu-elements/rds-popover/rds-popover.stories.tsx
@@ -243,6 +243,7 @@ export const WithList: Story = {
           title="Menu Options"
           width={250}
           position="no-arrow"
+          className="with-list-popover"
         >
           <List dense>
             {menuItems.map((item, index) => (


### PR DESCRIPTION
## Description
> Resolve the issues in Popover Element List story not looking good in small mobile screen: 
-  **Popover**
> Make the changes to stories file.
> Make changes in scss file.
## Screenshots :
 
<img width="1912" height="982" alt="image" src="https://github.com/user-attachments/assets/42168e94-498e-406a-a209-c5003b8e88d8" />
<img width="1920" height="986" alt="image" src="https://github.com/user-attachments/assets/444c95a5-97c2-4053-9cd1-85bf65e0ada9" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes