### PR TITLE
Resolved Bug 2975 : Design System > Element > Accordion > Dark theme > Field color is not same as per WF in dark mode

### DIFF
--- a/raaghu-elements/rds-accordion/rds-accordion.scss
+++ b/raaghu-elements/rds-accordion/rds-accordion.scss
@@ -13,8 +13,8 @@
 
 @include _rds-dark {
   .rds-accordion__container {  border-color: #44474A !important; }
-  .rds-accordion { background-color: #181A1B !important; }
-  .rds-accordion__summary { background-color: #181A1B !important; }
+  .rds-accordion { background-color: #202020 !important; }
+  .rds-accordion__summary { background-color: #202020 !important; }
   .rds-accordion__summary:hover { background-color: #1F2123 !important; }
   /* In dark mode, when in default state and hovered, title/icon should be white for readability */
   .rds-accordion__summary:hover .rds-accordion__title,
@@ -22,7 +22,7 @@
   .rds-accordion__summary:hover .MuiAccordionSummary-expandIconWrapper {
     color: #ffffff !important;
   }
-  .rds-accordion__details {  border-color: #44474A !important; }
+  .rds-accordion__details {  border-color: #44474A !important; background-color: #202020 !important; }
   .rds-accordion__details .MuiAccordionDetails-root,
   .rds-accordion__details .MuiAccordionDetails-root .MuiTypography-root { color: #E1E6EB !important; }
   .rds-accordion__title { color: #E1E6EB !important; }
@@ -38,6 +38,9 @@
     /* keep header background but make selected text/icons black */
     .rds-accordion__title { color: #000 !important; font-weight: 600 !important; }
     .rds-accordion__icon, .MuiAccordionSummary-expandIconWrapper { color: #000 !important; }
+  }
+  .rds-accordion__details-panel {
+    background: #202020 !important;
   }
 }
 .rds-accordion__container {


### PR DESCRIPTION
## Description
> Resolve the issues in Accordion Element field color is not as per WF : 
-  **Accordian**
> Make the changes to scss file.
## Screenshots :
 
<img width="1911" height="979" alt="image" src="https://github.com/user-attachments/assets/9e938a40-df91-43e3-8c08-39a353169a42" />
<img width="1913" height="980" alt="image" src="https://github.com/user-attachments/assets/5c7054c2-ac62-4152-855d-61b089febb90" />
<img width="1912" height="984" alt="image" src="https://github.com/user-attachments/assets/6b7b2668-b039-47cc-a473-4177990830bd" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes