### PR TITLE
Resolved Bug 2997 : In Tree Structure And Grid Make Responsiveess For Small And Large Screen

### DIFF
--- a/raaghu-components/rds-comp-grid/rds-comp-grid.tsx
+++ b/raaghu-components/rds-comp-grid/rds-comp-grid.tsx
@@ -1878,6 +1878,14 @@ const RdsCompGrid = forwardRef<RdsCompGridRef, RdsCompGridProps>(({
   const totalPages = Math.ceil(tableData.length / recordsPerPage);
   const activeFiltersCount = Object.keys(filterState).length + (searchValue ? 1 : 0);
 
+  // Minimal sync: when body scrolls horizontally, scroll header toolbar too
+  const headerScrollRef = React.useRef<HTMLDivElement | null>(null);
+  const handleBodyScroll: React.UIEventHandler<HTMLDivElement> = (e) => {
+    if (headerScrollRef.current) {
+      headerScrollRef.current.scrollLeft = (e.currentTarget as HTMLDivElement).scrollLeft;
+    }
+  };
+
   if (isLoading) {
     return (
       <Card sx={{ p: 2 }}>
@@ -1958,10 +1966,19 @@ const RdsCompGrid = forwardRef<RdsCompGridRef, RdsCompGridProps>(({
       }
     }}>
       {showHeader && (
-        <Box p={2} borderBottom="1px solid" borderColor="divider" sx={{
-          bgcolor: theme.palette.mode === 'dark' ? '#333333' : undefined
-        }}>
-          <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">
+        <Box
+          ref={headerScrollRef}
+          sx={{
+            overflowX: 'auto',
+            scrollbarWidth: 'none', // Firefox
+            msOverflowStyle: 'none', // IE/Edge Legacy
+            '&::-webkit-scrollbar': { height: 0 }, // WebKit
+          }}
+        >
+          <Box p={2} borderBottom="1px solid" borderColor="divider" sx={{
+            bgcolor: theme.palette.mode === 'dark' ? '#333333' : undefined
+          }}>
+            <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">
             <TextField
               placeholder="Search..."
               value={searchValue}
@@ -2000,7 +2017,8 @@ const RdsCompGrid = forwardRef<RdsCompGridRef, RdsCompGridProps>(({
                 <MoreIcon />
               </IconButton>
             </Stack>
-          </Stack>
+            </Stack>
+          </Box>
         </Box>
       )}
 
@@ -2090,7 +2108,8 @@ const RdsCompGrid = forwardRef<RdsCompGridRef, RdsCompGridProps>(({
 
       {!isCollapsed && (
         <TableContainer 
-          component={Paper} 
+          component={Paper}
+          onScroll={handleBodyScroll}
           elevation={0}
           sx={{
             bgcolor: theme.palette.mode === 'dark' ? '#333333' : undefined,

--- a/raaghu-elements/rds-carousel/rds-carousel.scss
+++ b/raaghu-elements/rds-carousel/rds-carousel.scss
@@ -277,17 +277,16 @@
   }
 }
 
-/* Storybook preview scrollbar suppression on small screens */
+/* Storybook preview scrollbar suppression on small screens (scoped to pages containing a Carousel) */
 @media (max-width: 320px) {
-  /* Try to target the iframe root and common storybook wrappers where the scrollbar appears */
-  html, body, .sb-show-main, .sb-previewBlock, .sb-previewBlock_body, .sb-wrapper {
+  /* Only apply when a carousel is present on the page */
+  :is(html, body, #storybook-root, .sb-show-main, .sb-previewBlock, .sb-previewBlock_body, .sb-wrapper):has(.rds-carousel) {
     overflow: hidden !important;
     -ms-overflow-style: none !important;
     scrollbar-width: none !important;
-    // width: 107% !important;
   }
 
-  html::-webkit-scrollbar, body::-webkit-scrollbar, #storybook-root::-webkit-scrollbar, .sb-show-main::-webkit-scrollbar, .sb-previewBlock_body::-webkit-scrollbar {
+  :is(html, body, #storybook-root, .sb-show-main, .sb-previewBlock, .sb-previewBlock_body, .sb-wrapper):has(.rds-carousel)::-webkit-scrollbar {
     display: none !important;
     width: 0 !important;
     height: 0 !important;


### PR DESCRIPTION

## Description
> Resolve the issues In Tree Structure And Grid Make Responsiveess For Small And Large Screen
-  **Tree Structure**
- **Grid**

## Screenshots :
1.Tree Structure > In Default story select control showCollapsed true and see in small screen page now scrollable at the end
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1c444705-15a1-46bf-8b0a-a042ba6fde7e" />

2.In Grid There are Grid Ref Story in small screen page now scrollable at bottom.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1e795293-d42b-4e7c-8a29-6f9626c7d350" />

3.In Grid All story small screen page not scrollable and also header now scrollable
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/06efe9ea-5b67-46a7-8727-ce6705cc0500" />
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
 