### PR TITLE
Revolved Bugs 3063 and 3064: Design System > Component > Typing section > Dropdown value is not in centered align and  Unable to display icon in dark mode

### DIFF
--- a/raaghu-components/rds-comp-ai-fab-menu/rds-comp-ai-fab-menu.scss
+++ b/raaghu-components/rds-comp-ai-fab-menu/rds-comp-ai-fab-menu.scss
@@ -389,6 +389,12 @@
   background-color: var(--rds-color-primary-container-dark, #1565c0);
 }
 
+[data-theme="dark"] .rds-fab-menu__button--light,
+.dark-theme .rds-fab-menu__button--light,
+.theme-dark .rds-fab-menu__button--light {
+  background-color: #a7aaae !important;
+}
+
 // High contrast mode support
 @media (prefers-contrast: high) {
   .rds-fab-menu {

--- a/raaghu-components/rds-comp-ai-typing-section/rds-comp-ai-typing-section.scss
+++ b/raaghu-components/rds-comp-ai-typing-section/rds-comp-ai-typing-section.scss
@@ -236,6 +236,13 @@
     }
   }
 
+  /* Autocomplete container default sizing */
+  &__autocomplete {
+    /* Allow it to grow and take remaining horizontal space while capping at a max width */
+    flex: 1 1 auto;
+    max-width: var(--ai-typing-autocomplete-max-width, 60px);
+    min-width: 190px;
+  }
   /* Explicitly ensure large/normal screens use row layout (reset small-screen column rules) */
   @media (min-width: 376px) {
     &__project-actions {

--- a/raaghu-components/rds-comp-ai-typing-section/rds-comp-ai-typing-section.tsx
+++ b/raaghu-components/rds-comp-ai-typing-section/rds-comp-ai-typing-section.tsx
@@ -17,6 +17,7 @@ export interface RdsCompAiTypingSectionProps {
   previewImage?: string;
   type?: string;
   warningMsg?: boolean;
+  autoCompleteMaxWidth?: string; 
 }
 declare global {
   interface Window {
@@ -32,7 +33,8 @@ const RdsCompAiTypingSection: React.FC<RdsCompAiTypingSectionProps> = ({
   previewImage,
   type,
   warningMsg,
-  onAddComment
+  onAddComment,
+  autoCompleteMaxWidth
 }) => {
   const [inputText, setInputText] = useState<string>("");
   const [prevInputText, setPrevInputText] = useState<string>("");
@@ -200,7 +202,10 @@ const RdsCompAiTypingSection: React.FC<RdsCompAiTypingSectionProps> = ({
             />
           </div>
         </div>
-        <div className="rds-comp-ai-chat-bot__autocomplete">
+        <div
+          className="rds-comp-ai-chat-bot__autocomplete"
+          style={autoCompleteMaxWidth ? { ['--ai-typing-autocomplete-max-width' as any]: autoCompleteMaxWidth } : undefined}
+        >
           <RdsAutocomplete
             controlStyle="default"
             helperText="Select one of the available options"


### PR DESCRIPTION
## Description
> Resolve the issues on Element Radio button unable to select: 
-  **Typing section**
> Dropdown is now looking proper.
- **Fab menu**
> Now in dark mode it's looking good.
## Screenshots :
 
<img width="1919" height="982" alt="image" src="https://github.com/user-attachments/assets/13faf608-5c9a-45cd-b011-ff678e38a943" />
<img width="1915" height="981" alt="image" src="https://github.com/user-attachments/assets/8551e982-e617-4802-a8a1-a0c4ae37f386" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes