### PR TITLE
Resolved Bug 3080: Design System > Elements > Drawer > Persistent > Button is not in centered align

### DIFF
--- a/raaghu-elements/rds-drawer/rds-drawer.scss
+++ b/raaghu-elements/rds-drawer/rds-drawer.scss
@@ -97,3 +97,32 @@
 .rds-drawer-close-button {
   margin-left: 20px;
 }
+
+// Story-specific styles for centering trigger button
+.rds-drawer-trigger-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  min-height: 200px;
+}
+
+// Responsive centering for persistent drawer trigger
+.rds-drawer-persistent-trigger {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  min-height: 200px;
+  padding: var(--rds-spacing-lg);
+  
+  @media (max-width: 768px) {
+    min-height: 150px;
+    padding: var(--rds-spacing-md);
+  }
+  
+  @media (max-width: 480px) {
+    min-height: 120px;
+    padding: var(--rds-spacing-sm);
+  }
+}

--- a/raaghu-elements/rds-drawer/rds-drawer.stories.tsx
+++ b/raaghu-elements/rds-drawer/rds-drawer.stories.tsx
@@ -57,11 +57,12 @@ export const Default: Story = {
     showTrigger: true,
     triggerText: 'Open Drawer',
     anchor: 'left',
+    centerTrigger: true,
     children: drawerContent,
   },
 };
 Default.parameters = {
-  controls: { include: ['showTrigger', 'triggerText', 'anchor', 'children', 'variant'] },
+  controls: { include: ['showTrigger', 'triggerText', 'anchor', 'children', 'variant', 'centerTrigger'] },
 };
 
 export const Right: Story = {
@@ -69,11 +70,12 @@ export const Right: Story = {
     showTrigger: true,
     triggerText: 'Open Drawer',
     anchor: 'right',
+    centerTrigger: true,
     children: drawerContent,
   },
 };
 Right.parameters = {
-  controls: { include: ['showTrigger', 'triggerText', 'anchor', 'children', 'variant'] },
+  controls: { include: ['showTrigger', 'triggerText', 'anchor', 'children', 'variant', 'centerTrigger'] },
 };
 
 export const Top: Story = {
@@ -81,6 +83,7 @@ export const Top: Story = {
     showTrigger: true,
     triggerText: 'Open Drawer',
     anchor: 'top',
+    centerTrigger: true,
     children: (
       <div style={{ height: 200, padding: '16px' }}>
         <Typography variant="h6" gutterBottom>
@@ -92,7 +95,7 @@ export const Top: Story = {
   },
 };
 Top.parameters = {
-  controls: { include: ['showTrigger', 'triggerText', 'anchor', 'children', 'variant'] },
+  controls: { include: ['showTrigger', 'triggerText', 'anchor', 'children', 'variant', 'centerTrigger'] },
 };
 
 export const Bottom: Story = {
@@ -100,6 +103,7 @@ export const Bottom: Story = {
     showTrigger: true,
     triggerText: 'Open Drawer',
     anchor: 'bottom',
+    centerTrigger: true,
     children: (
       <div style={{ height: 200, padding: '16px' }}>
         <Typography variant="h6" gutterBottom>
@@ -111,7 +115,7 @@ export const Bottom: Story = {
   },
 };
 Bottom.parameters = {
-  controls: { include: ['showTrigger', 'triggerText', 'anchor', 'children', 'variant'] },
+  controls: { include: ['showTrigger', 'triggerText', 'anchor', 'children', 'variant', 'centerTrigger'] },
 };
 
 export const Persistent: Story = {
@@ -121,11 +125,13 @@ export const Persistent: Story = {
     triggerTextWhenOpen: 'Close Persistent Drawer',
     variant: 'persistent',
     anchor: 'left',
+    centerTrigger: true,
+    triggerWrapperClassName: 'rds-drawer-persistent-trigger',
     children: drawerContent,
   },
 };
 Persistent.parameters = {
-  controls: { include: ['showTrigger', 'triggerText', 'anchor', 'children', 'variant', 'triggerTextWhenOpen'] },
+  controls: { include: ['showTrigger', 'triggerText', 'anchor', 'children', 'variant', 'triggerTextWhenOpen', 'centerTrigger'] },
 };
 
 export const Interactive: Story = {
@@ -133,6 +139,7 @@ export const Interactive: Story = {
     showTrigger: true,
     triggerText: 'Open Drawer',
     anchor: 'left',
+    centerTrigger: true,
     showCloseButton: true,
     closeButtonText: 'Close Drawer',
     children: (
@@ -145,5 +152,5 @@ export const Interactive: Story = {
   },
 };
 Interactive.parameters = {
-  controls: { include: ['showTrigger', 'triggerText', 'anchor', 'children', 'variant', 'showCloseButton'] },
+  controls: { include: ['showTrigger', 'triggerText', 'anchor', 'children', 'variant', 'showCloseButton', 'centerTrigger'] },
 };

--- a/raaghu-elements/rds-drawer/rds-drawer.tsx
+++ b/raaghu-elements/rds-drawer/rds-drawer.tsx
@@ -23,6 +23,10 @@ export interface RdsDrawerProps extends DrawerProps {
   closeButtonText?: string;
   /** Additional props forwarded to the close RdsButton. */
   closeButtonProps?: Partial<React.ComponentProps<typeof RdsButton>>;
+  /** When true, wraps the trigger button in a centered container (useful for stories). */
+  centerTrigger?: boolean;
+  /** CSS class name for the trigger wrapper container. */
+  triggerWrapperClassName?: string;
 }
 
 const RdsDrawer: React.FC<RdsDrawerProps> = ({
@@ -39,6 +43,8 @@ const RdsDrawer: React.FC<RdsDrawerProps> = ({
   showCloseButton = false,
   closeButtonText = 'Close Drawer',
   closeButtonProps,
+  centerTrigger = false,
+  triggerWrapperClassName,
   ...props
 }) => {
   const drawerAnchor = anchor || position;
@@ -117,20 +123,36 @@ const RdsDrawer: React.FC<RdsDrawerProps> = ({
   );
 
   if (showTrigger) {
+    const triggerButton = (
+      <RdsButton
+        text={getButtonText()}
+        onClick={triggerTextWhenOpen ? handleToggle : handleToggle}
+        color="primary"
+        layout="text-only"
+        shape="rectangle"
+        size="medium"
+        state="default"
+        style="filled"
+        textCase="unset"
+        {...triggerButtonProps}
+      />
+    );
+
+    if (centerTrigger) {
+      const wrapperClass = triggerWrapperClassName || 'rds-drawer-trigger-wrapper';
+      return (
+        <>
+          <div className={wrapperClass}>
+            {triggerButton}
+          </div>
+          {drawerElement}
+        </>
+      );
+    }
+
     return (
       <>
-        <RdsButton
-          text={getButtonText()}
-          onClick={triggerTextWhenOpen ? handleToggle : handleToggle}
-          color="primary"
-          layout="text-only"
-          shape="rectangle"
-          size="medium"
-          state="default"
-          style="filled"
-          textCase="unset"
-          {...triggerButtonProps}
-        />
+        {triggerButton}
         {drawerElement}
       </>
     );


### PR DESCRIPTION
## Description
> Resolve the issues on Element Drawer persistent story different screen sizes: 
-  **Drawer**
> Make look good center in different screen sizes.
## Screenshots :
 
<img width="1917" height="983" alt="image" src="https://github.com/user-attachments/assets/77096f46-9c30-4d85-ab8d-43aa4b231f0d" />
<img width="1913" height="982" alt="image" src="https://github.com/user-attachments/assets/1b7ebd05-0d72-4b5c-b957-dad7c088a3bb" />

<img width="1912" height="979" alt="image" src="https://github.com/user-attachments/assets/7a76761f-eedb-4bc0-bc78-715db666e3f0" />
<img width="1919" height="991" alt="image" src="https://github.com/user-attachments/assets/181feef6-0c2d-4a7e-be88-9d044ddadd83" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes