### PR TITLE
Resolved Bug 3041: Design System > Component > Application shell > Tri pane > The icon is not visible in system dark mode

### DIFF
--- a/raaghu-layouts/rds-comp-app-shell/rds-comp-app-shell.stories.tsx
+++ b/raaghu-layouts/rds-comp-app-shell/rds-comp-app-shell.stories.tsx
@@ -535,7 +535,6 @@ export const TriPane: Story = {
             showLogo={false}
           />
         </div>
-        {/* Add Layout message in the center, full height */}
         <div className="rds-appshell-add-layout-flex-center">
           <span className="rds-appshell-add-layout-text">Add Layout</span>
         </div>

--- a/raaghu-layouts/rds-comp-app-shell/rds-comp-app-shell.stories.tsx
+++ b/raaghu-layouts/rds-comp-app-shell/rds-comp-app-shell.stories.tsx
@@ -540,7 +540,12 @@ export const TriPane: Story = {
           <span className="rds-appshell-add-layout-text">Add Layout</span>
         </div>
         <div id="detail-pane-one-three-one">
-          <RdsCompDetailsPane style="Toolbar" headerText={""} />
+          <RdsCompDetailsPane 
+            style="Toolbar" 
+            headerText={""} 
+            figmaIconSrc="assets/figma.png"
+            storybookIconSrc="assets/storybook.png"
+          />
         </div>
       </div>
     ),


### PR DESCRIPTION
## Description
> Resolve the issues on Component application shell tri pane: 
-  **Application shell tri pane**
> Added icon to the both buttons.
## Screenshots :
 
<img width="1919" height="985" alt="image" src="https://github.com/user-attachments/assets/abf51cff-e077-491e-8e8c-fb3e7757d99f" />
<img width="1913" height="980" alt="image" src="https://github.com/user-attachments/assets/36439434-85b2-45c6-b354-11e16231ed1e" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes