### PR TITLE
Resolved Bug 3116: Design System > Elements > Counter > The counter color is not the same in dark and light mode

### DIFF
--- a/raaghu-elements/rds-counter/rds-counter.scss
+++ b/raaghu-elements/rds-counter/rds-counter.scss
@@ -512,14 +512,7 @@
   
   // Counter buttons for dark theme
   &__button {
-    background-color: var(--rds-color-primary, #7e2eef) !important;
     color: var(--rds-primary-contrast-text, #ffffff) !important;
-    border: 1px solid var(--rds-color-primary, #7e2eef) !important;
-    
-    &:hover:not(&--disabled) {
-      background-color: var(--rds-color-primary-dark, #4f00a6) !important;
-      border-color: var(--rds-color-primary-dark, #4f00a6) !important;
-    }
     
     &:focus {
 
@@ -552,8 +545,6 @@
     &--large,
     &--increment,
     &--decrement {
-      background-color: var(--rds-color-primary, #7e2eef) !important;
-      border-color: var(--rds-color-primary, #7e2eef) !important;
       color: var(--rds-primary-contrast-text, #ffffff) !important;
     }
   }
@@ -659,7 +650,6 @@
   // Button interaction states
   &__button {
     &:active:not(&--disabled) {
-      background-color: var(--rds-color-primary-dark, #4f00a6) !important;
       transform: translateY(1px);
       transition: all 0.1s ease;
     }


### PR DESCRIPTION

## Description
> Resolve the issues on Element counter buttons color is not as per fimga that fixed: 
-  **Counter**
> Make the changes in scss file.
## Screenshots :
 
<img width="1916" height="983" alt="image" src="https://github.com/user-attachments/assets/e20915c1-740b-4c7b-bc33-36fcb460e6d7" />
<img width="1915" height="981" alt="image" src="https://github.com/user-attachments/assets/e7ef03b7-ffdf-4c43-b04f-ccc6f860bcec" />
<img width="1907" height="984" alt="image" src="https://github.com/user-attachments/assets/0310ff70-27ba-4a4a-90ed-0e7c0f3d42a1" />
<img width="1920" height="974" alt="image" src="https://github.com/user-attachments/assets/6462e7df-7135-46a0-b1b1-4f0ddd9ea4cf" />
<img width="1912" height="978" alt="image" src="https://github.com/user-attachments/assets/2e731df4-a5e7-481e-abec-d6b367656247" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes