### PR TITLE
Resolved Bugs 3098 and 3104 : Design System > Element > Form control > Alignment of text is incorrect and Toggle button > Color control is not working

### DIFF
--- a/raaghu-elements/rds-form-control/rds-form-control.scss
+++ b/raaghu-elements/rds-form-control/rds-form-control.scss
@@ -24,9 +24,9 @@
 .rds-form-control .MuiFormLabel-root.Mui-error .MuiFormLabel-asterisk {
   color: #d32f2f !important;
 }
-.css-1t6h741-MuiFormHelperText-root{
-  margin-left:0 !important;
-}
-.css-196gpye-MuiFormHelperText-root{
-  margin-left:0 !important;
+
+// Fix helper text alignment - override MUI's default margin
+.rds-form-control .MuiFormHelperText-root,
+.rds-form-control .css-1t6h741-MuiFormHelperText-root {
+  margin-left: 0 !important;
 }

--- a/raaghu-elements/rds-toggle-button/rds-toggle-button.stories.tsx
+++ b/raaghu-elements/rds-toggle-button/rds-toggle-button.stories.tsx
@@ -248,6 +248,11 @@ Secondary.parameters = {
 };
 
 export const StandaloneToggleButton: Story = {
+  args: {
+    color: 'primary',
+    size: 'medium',
+    disabled: false,
+  },
   parameters: {
     docs: {
       description: {
@@ -260,10 +265,12 @@ export const StandaloneToggleButton: Story = {
       }
     },
   },
-  render: () => (
+  render: (args) => (
       <RdsStandaloneToggleButton
         value="check"
-        color="primary"
+        color={args.color}
+        size={args.size}
+        disabled={args.disabled}
         aria-label="Toggle check"
       >
         <Check />
@@ -271,7 +278,7 @@ export const StandaloneToggleButton: Story = {
   )
 };
 StandaloneToggleButton.parameters = {
-  controls: { include: ['options', 'defaultValue', 'size', 'color', 'orientation', 'spacing'] },
+  controls: { include: ['size', 'color', 'disabled'] },
 };
 
 export const UncontrolledWithDisplay: Story = {


### PR DESCRIPTION

## Description
> Resolve the issues on Element: 
-  **Form Control**
> Make the changes to scss file.
- **Toggle Button**
> In standalone toggle button story color control is working.
## Screenshots :
 
<img width="1907" height="983" alt="image" src="https://github.com/user-attachments/assets/67eb98fb-d550-42d3-83ce-e2917784d6cf" />
<img width="1906" height="983" alt="image" src="https://github.com/user-attachments/assets/ff06013d-9d16-43ae-b966-79dfae3a3df4" />
<img width="1911" height="976" alt="image" src="https://github.com/user-attachments/assets/eff1669d-2002-4c66-9fe7-f3af6208c060" />
<img width="1913" height="989" alt="image" src="https://github.com/user-attachments/assets/024eb907-e9cf-478b-9ca2-718e5e5ffb3a" />
<img width="1913" height="981" alt="image" src="https://github.com/user-attachments/assets/8fe76848-b18c-4c0f-8520-694a9113c06e" />
<img width="1917" height="980" alt="image" src="https://github.com/user-attachments/assets/9b8505af-3275-43e7-8372-02c08cd92907" />
<img width="1908" height="979" alt="image" src="https://github.com/user-attachments/assets/389ba760-085e-4b3b-9095-920c9383c884" />
<img width="1911" height="979" alt="image" src="https://github.com/user-attachments/assets/e933a52b-2f3c-4988-a52c-b3b82c0746ff" />
<img width="1910" height="980" alt="image" src="https://github.com/user-attachments/assets/0144f9e6-dfe4-47e3-9530-1e714fc33d92" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes