### PR TITLE
Resolved Bugs 3138 and 3139 : Design system > Element > Autocomplete > Field size is changing and Dialog > Background color of button is different than WF

### DIFF
--- a/raaghu-elements/rds-autocomplete/rds-autocomplete.scss
+++ b/raaghu-elements/rds-autocomplete/rds-autocomplete.scss
@@ -143,10 +143,7 @@
     }
   }
 
-  // Interactive states
-  &:hover {
-    // Hover styles if needed
-  }
+  // Interactive states - hover styles can be added here if needed
 
   &:focus-visible {
     outline: 2px solid var(--rds-color-primary, #005fcc);
@@ -171,5 +168,18 @@
 
   .MuiFormHelperText-root {
     margin-left: 0 !important;
+    min-height: 20px !important; // Ensure consistent height
+    margin-top: 3px !important;
+    margin-bottom: 0 !important;
+    line-height: 1.2 !important;
+  }
+
+  // When helper text should be hidden but maintain layout space
+  &__textfield--hidden-helper {
+    .MuiFormHelperText-root {
+      color: transparent !important;
+      visibility: visible !important; // Keep visible for layout spacing
+      user-select: none !important; // Prevent text selection of hidden content
+    }
   }
 }

--- a/raaghu-elements/rds-autocomplete/rds-autocomplete.tsx
+++ b/raaghu-elements/rds-autocomplete/rds-autocomplete.tsx
@@ -138,10 +138,10 @@ const RdsAutocomplete = <T extends { label?: string },>({
         <TextField
           {...params}
           placeholder={placeholder}
-          helperText={showHintText ? helperText : ''}
+          helperText={helperText || '\u00A0'}
           error={error}
           variant={variant}
-          className={`rds-autocomplete__textfield ${sizeClass} ${controlStyleClass}`}
+          className={`rds-autocomplete__textfield ${sizeClass} ${controlStyleClass} ${!showHintText ? 'rds-autocomplete__textfield--hidden-helper' : ''}`}
           onClick={() => state !== 'expanded' && setOpen(true)}
           onFocus={() => openOnFocus && state !== 'expanded' && setOpen(true)}
         />

--- a/raaghu-elements/rds-dialog/rds-dialog.scss
+++ b/raaghu-elements/rds-dialog/rds-dialog.scss
@@ -115,7 +115,7 @@
       justify-content: center;
       align-items: center;
       padding: 0 12px;
-      background: var(--rds-color-primary, #3C98FF);
+      //background: var(--rds-color-primary, #3C98FF);
       color: var(--rds-primary-contrast-text, #fff);
       border-radius: 8px; /* match Figma corner radius */
       border: none;
@@ -260,15 +260,8 @@
   
   // Dialog buttons for dark theme - maintain same appearance as light theme
   &__button {
-    // Base button should inherit from light theme styling
-   // background: var(--rds-background-paper, #fff) !important;
-    color: var(--rds-color-primary, #3c98ff) !important;
-    //border: 1px solid var(--rds-color-primary, #3c98ff) !important;
+    color: var(--rds-color-primary, #ffffff) !important;
     border-radius: var(--rds-border-radius, 6px) !important;
-
-    &:hover {
-      background: var(--rds-color-primary-hover-bg, #4a4a4a) !important;
-    }
     
     &:focus {
       outline: 2px solid var(--rds-color-primary, #3c98ff) !important;
@@ -282,7 +275,7 @@
       border: none !important;
 
       &:hover {
-        background: var(--rds-color-primary-hover, #1976d2) !important;
+        background: var(--rds-color-primary-hover, #056cd3) !important;
       }
     }
     
@@ -299,13 +292,13 @@
     
     // Dismiss/text button variant - use same colors as light theme
     &__dismiss {
-      background: #3C98FF !important;
-      color: var(--rds-color-primary, #fff) !important;
+      //background: #3C98FF !important;
+      color: var(--rds-color-primary, #1976d2) !important;
       border: none !important;
-      
-      &:hover {
-        background: var(--rds-color-primary-hover-bg, #2e7ce0) !important;
-      }
+
+     &:hover {
+      background: var(--rds-color-primary-hover-bg, #4a4a4a) !important;
+    }
     }
   }
   

--- a/raaghu-elements/rds-dialog/rds-dialog.tsx
+++ b/raaghu-elements/rds-dialog/rds-dialog.tsx
@@ -69,13 +69,14 @@ const RdsDialog = ({
             <RdsButton
               onClick={onClose}
               className="rds-dialog__button rds-dialog__button__dismiss"
-              style="filled"
+              
             >Cancel</RdsButton>
           )}
           {ShowPrimary && (
             <RdsButton
               onClick={onClose}
               className="rds-dialog__button rds-dialog__button__primary-link"
+              style="filled"
               text="Okay"
             />
           )}


### PR DESCRIPTION
## Description
> Resolve the issues on Element: 
-  **Autocomplete**
> Make the changes to scss file.
- **Dialog**
> Both buttons are now as per wire frame.
## Screenshots :
 
<img width="1901" height="972" alt="image" src="https://github.com/user-attachments/assets/c65814cc-c0e9-44d0-9c6a-87f6eef3f87f" />
<img width="1908" height="990" alt="image" src="https://github.com/user-attachments/assets/d60f4f76-2427-4972-be98-15b17cfe2b8c" />
<img width="1913" height="981" alt="image" src="https://github.com/user-attachments/assets/b7e71bba-c869-4373-92cd-0e7d99ce0aeb" />
<img width="1912" height="979" alt="image" src="https://github.com/user-attachments/assets/ddc817df-8848-4c96-b129-91e87ac1a3da" />
<img width="1908" height="970" alt="image" src="https://github.com/user-attachments/assets/2ac89ec3-1b87-4d52-9352-fafe52fec6b2" />
<img width="1913" height="976" alt="image" src="https://github.com/user-attachments/assets/19a4e4f5-1651-4e6d-8633-fcd1f2ea0fa9" />
<img width="1905" height="985" alt="image" src="https://github.com/user-attachments/assets/81d28cdc-698e-4c19-82c5-bc6495998e06" />
<img width="1900" height="975" alt="image" src="https://github.com/user-attachments/assets/e42c35c8-1fd8-4ac7-84b0-7099767f6a59" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes