### PR TITLE
Resolved Bug 3184 : Design System > Components > Details pane > Toolbar > Style > In dark theme file icon color is different than light theme

### DIFF
--- a/raaghu-components/rds-comp-tree-structure/rds-comp-tree-structure.scss
+++ b/raaghu-components/rds-comp-tree-structure/rds-comp-tree-structure.scss
@@ -70,6 +70,12 @@
     &--folder {
       color: var(--rds-color-warning, #FFB300);
       margin-top: var(--rds-spacing-sm, 2px);
+      
+      svg,
+      svg * {
+        fill: currentColor !important;
+        color: inherit !important;
+      }
     }
     
     &--file {


### PR DESCRIPTION
## Description
> Resolve the issues on Component: 
-  **Details Pane**
> Make the changes to scss file.
> Make file icon color same in dark mode as per WF.
## Screenshots :
 
<img width="1918" height="985" alt="image" src="https://github.com/user-attachments/assets/595600e4-b007-468e-b20c-e243c42ae0e4" />
<img width="1920" height="987" alt="image" src="https://github.com/user-attachments/assets/93475927-0476-44c7-b1b6-3b80300e69a2" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes