### PR TITLE
Resolved Bugs 3238 and 3247 : Design System > Elements > Side nav > TextField > Missing space between two words and  Component > Details Pane > Double scroll bar is display

### DIFF
--- a/raaghu-components/rds-comp-details-pane/rds-comp-details-pane.scss
+++ b/raaghu-components/rds-comp-details-pane/rds-comp-details-pane.scss
@@ -1123,8 +1123,7 @@
     max-width: 100vw;
     padding: 8px;        
     gap: var(--rds-spacing-sm, 12px);
-    overflow-y: auto;
-    overflow-x: hidden;
+    overflow: hidden; // Remove overflow from main container
     &__header {
       
       margin-left: 8px !important;
@@ -1186,15 +1185,52 @@
       padding-left: var(--rds-spacing-xs, 6px);
       padding-right: var(--rds-spacing-xs, 6px);
       padding-bottom: var(--rds-spacing-sm, 8px);
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
     }
     
     &__selection-container {
       padding-top: var(--rds-spacing-xxs, 4px);
       padding-bottom: var(--rds-spacing-xxs, 4px);
+      flex: 1;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
     }
     
     &__tab-container {
       padding: 0 var(--rds-spacing-xs, 8px);
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      overflow: hidden;
+    }
+    
+    &__tab-pane {
+      flex: 1;
+      overflow-y: auto;
+      overflow-x: hidden;
+      height: calc(100% - 60px); // Account for tab buttons height
+      
+      // Custom scrollbar for mobile
+      &::-webkit-scrollbar {
+        width: 4px;
+      }
+      
+      &::-webkit-scrollbar-track {
+        background: transparent;
+      }
+      
+      &::-webkit-scrollbar-thumb {
+        background: var(--rds-color-border, #e0e0e0);
+        border-radius: 2px;
+        
+        &:hover {
+          background: var(--rds-color-text-tertiary, #adb5bd);
+        }
+      }
     }
     
     &__tab-btn {
@@ -1226,6 +1262,27 @@
       gap: var(--rds-spacing-xs, 6px);
       margin-top: var(--rds-spacing-sm, 8px);
       margin-bottom: var(--rds-spacing-lg, 16px);
+      overflow-y: auto;
+      overflow-x: hidden;
+      max-height: calc(100vh - 200px);
+      
+      // Custom scrollbar for mobile
+      &::-webkit-scrollbar {
+        width: 4px;
+      }
+      
+      &::-webkit-scrollbar-track {
+        background: transparent;
+      }
+      
+      &::-webkit-scrollbar-thumb {
+        background: var(--rds-color-border, #e0e0e0);
+        border-radius: 2px;
+        
+        &:hover {
+          background: var(--rds-color-text-tertiary, #adb5bd);
+        }
+      }
     }
     
     &__favourite-card {
@@ -1469,6 +1526,21 @@
       height: var(--rds-input-height-sm, 32px);
     }
   }
+
+  /* Hide outer page/viewport scrollbar on very small screens so only the
+     component's inner scrollbar is visible (keeps inner overflow auto).
+     This targets narrow viewports where the details pane acts like an overlay. */
+  html, body {
+    overflow: hidden !important;
+    -ms-overflow-style: none !important; /* IE and Edge */
+    scrollbar-width: none !important; /* Firefox */
+  }
+  html::-webkit-scrollbar, body::-webkit-scrollbar {
+    display: none !important;
+    width: 0 !important;
+    height: 0 !important;
+  }
+
 }
 @media screen and (min-width: 414px) {
   .rds-comp-details-pane {

--- a/raaghu-components/rds-comp-details-pane/rds-comp-details-pane.scss
+++ b/raaghu-components/rds-comp-details-pane/rds-comp-details-pane.scss
@@ -1123,7 +1123,7 @@
     max-width: 100vw;
     padding: 8px;        
     gap: var(--rds-spacing-sm, 12px);
-    overflow: hidden; // Remove overflow from main container
+    overflow: hidden; 
     &__header {
       
       margin-left: 8px !important;

--- a/raaghu-elements/rds-text-field/rds-text-field.stories.tsx
+++ b/raaghu-elements/rds-text-field/rds-text-field.stories.tsx
@@ -4,7 +4,7 @@ import { Email, Lock, Search } from '@mui/icons-material';
 import { InputAdornment } from '@mui/material';
 
 const meta: Meta<typeof RdsTextField> = {
-  title: 'Elements/TextField',
+  title: 'Elements/Text Field',
   component: RdsTextField,
   parameters: {
     layout: 'padded',


### PR DESCRIPTION
## Description
> Resolve the issues on Element and Components: 
-  **Text Field**
> Make the changes to stories file.
- **Details Pane**
> Remove the scrollbar for small screensize.
## Screenshots :
 
<img width="1920" height="985" alt="image" src="https://github.com/user-attachments/assets/3e80cb34-9716-42b7-b344-f1b4c3fb4696" />
<img width="1920" height="986" alt="image" src="https://github.com/user-attachments/assets/155cf07b-214e-4716-a581-90f8c5c31419" />
<img width="1918" height="983" alt="image" src="https://github.com/user-attachments/assets/3cf73021-26f9-4919-ab96-050d527eed25" />
<img width="1920" height="987" alt="image" src="https://github.com/user-attachments/assets/527f54d3-38cd-4050-962c-ed9745b33d1c" />
<img width="1920" height="985" alt="image" src="https://github.com/user-attachments/assets/a700b635-8ea9-4955-b34c-01d03613d21b" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes