### PR TITLE
Resolved Bug 3490: Design system > Elements > Breadcrumbs > Unable to see icons in dark mode

### DIFF
--- a/raaghu-elements/rds-breadcrumbs/rds-breadcrumbs.scss
+++ b/raaghu-elements/rds-breadcrumbs/rds-breadcrumbs.scss
@@ -1,6 +1,13 @@
 // RDS Breadcrumbs Component Styles
 // Breadcrumb navigation
 
+[data-theme="dark"],
+.dark-theme {
+  .css-1jncskg-MuiSvgIcon-root {
+    fill: var(--rds-color-primary, #1976d2) !important;
+  }
+}
+
 .rds-breadcrumbs {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Description
> Resolve the issues on Element Breadcrumbs : 
-  **Breadcrumbs **
> Make the changes to SCSS file.
## Screenshots :
 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/565217e0-acde-454d-8d91-78c6a09c3467" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d2dba2c8-7d4a-45bf-b46e-6fc94bf9792b" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
 
 