### PR TITLE
Resolved Bug 3519, 3522 and 3544 : Design System > Element > Multi level menu > Small and large mobile screen > opening 2nd menu operlapping current menu > it should open below it

### DIFF
--- a/raaghu-components/rds-comp-color-picker/rds-comp-color-picker.scss
+++ b/raaghu-components/rds-comp-color-picker/rds-comp-color-picker.scss
@@ -633,8 +633,8 @@
   --rds-color-outline-variant: rgba(255,255,255,0.04);
   --rds-color-on-surface: #E6E7E8;
   --rds-color-on-surface-variant: #bfc2c4;
-  --rds-color-primary: #7c3aed;
-  --rds-color-primary-container: rgba(124,58,237,0.12);
+  --rds-color-primary: #1976d2;
+  --rds-color-primary-container: rgba(25,118,210,0.12);
   --rds-color-error: #ef5350;
   color: var(--rds-color-on-surface);
 

--- a/raaghu-components/rds-comp-kanban-board/rds-comp-kanban-board.scss
+++ b/raaghu-components/rds-comp-kanban-board/rds-comp-kanban-board.scss
@@ -915,8 +915,7 @@ html[data-theme="dark"],
   }
   
   .rds-kanban-board__sub-card-text.f-14.fw-400 {
-    /* minimal change: slightly darker text for readability in dark theme */
-    color: var(--rds-kanban-subcard-text-dark, #353535) !important;
+    color: var(--rds-kanban-subcard-text-dark, #7D7D7D) !important;
   }
   
   .rds-kanban-board__sub-card-footer-left.f-12.fw-500 {

--- a/raaghu-elements/rds-multi-level-menu/rds-multi-level-menu.tsx
+++ b/raaghu-elements/rds-multi-level-menu/rds-multi-level-menu.tsx
@@ -5,6 +5,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import ListItemText from '@mui/material/ListItemText';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import CheckIcon from '@mui/icons-material/Check';
 import RdsButton from '../rds-button/rds-button';
 import { Box } from '@mui/material';
@@ -162,7 +163,11 @@ export const RdsMultiLevelMenu = ({
                         setSubmenuAnchor(level, e.currentTarget as HTMLElement, idx);
                       }}
                     >
-                      <ChevronRightIcon fontSize="small" />
+                      {isMobile ? (
+                        <KeyboardArrowDownIcon fontSize="small" />
+                      ) : (
+                        <ChevronRightIcon fontSize="small" />
+                      )}
                     </Box>
                   )}
                 </Box>


### PR DESCRIPTION
## Description
> Resolve the issues on Design System: 
-  **Multi level Menu**
- **Color Picker**
- **Kanban Board**

> Changed the primary color variables in the color picker SCSS to a blue shade. Adjusted sub-card text color in the Kanban board dark theme for better readability. Updated the multi-level menu to use a downward arrow icon on mobile devices instead of a right arrow.
## Screenshots :
 <img width="1920" height="985" alt="image" src="https://github.com/user-attachments/assets/2b9c9690-7010-4df6-913f-0f72c5d34ece" />
<img width="1918" height="983" alt="image" src="https://github.com/user-attachments/assets/d7c7edfd-43d2-43c4-b2de-dfbac5681886" />
<img width="1920" height="988" alt="image" src="https://github.com/user-attachments/assets/9f034781-821c-49dc-a132-d67ca780c5e9" />
<img width="1920" height="983" alt="image" src="https://github.com/user-attachments/assets/27e3b66a-0c02-4013-ba7b-7b46f06f8a38" />
<img width="1920" height="982" alt="image" src="https://github.com/user-attachments/assets/fa2db85a-6246-4704-91c3-79565f240bd5" />
<img width="1910" height="977" alt="image" src="https://github.com/user-attachments/assets/864347d5-b892-4032-a023-4d9173760957" />
<img width="1907" height="980" alt="image" src="https://github.com/user-attachments/assets/5e53aadd-6b84-43f3-8d18-32a62af8a6ac" />
<img width="1907" height="978" alt="image" src="https://github.com/user-attachments/assets/005bcb3c-844a-43ac-8eeb-0f14cb12a823" />
<img width="1910" height="980" alt="image" src="https://github.com/user-attachments/assets/6abbf868-dca1-428c-95ee-873fee8c4994" />
<img width="1911" height="983" alt="image" src="https://github.com/user-attachments/assets/8b90c4dc-8d42-41bc-af10-5ef8e7eaf68d" />
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
