### PR TITLE
Resolved Bug 3017 : Design System > Remove usage of --legacy-peer-deps in npm install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,9 +114,9 @@
     "react-svg-worldmap": "^2.0.0-alpha.16",
     "react-syntax-highlighter": "^15.5.0",
     "rimraf": "^6.0.1",
-    "slate": "^0.118.0",
+    "slate": "^0.123.0",
     "slate-history": "^0.113.1",
-    "slate-react": "^0.117.4",
+    "slate-react": "^0.120.0",
     "wavesurfer.js": "^7.10.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "rimraf": "^6.0.1",
     "slate": "^0.123.0",
     "slate-history": "^0.113.1",
-    "slate-react": "^0.120.0",
+    "slate-react": "^0.117.4",
     "wavesurfer.js": "^7.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
> Resolve the issues on Design System: 
-  **Remove usage of --legacy-peer-deps**
> 'slate' to version 0.123.0 and 'slate-react' to 0.120.0 in package.json to keep dependencies up to date.
## Screenshots :
 
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
