### PR TITLE
Resolved Bug-2367-Design System > Element > Show code button is overlapped.

### DIFF
--- a/.storybook/custom-theme.css
+++ b/.storybook/custom-theme.css
@@ -21,6 +21,10 @@ body.theme-dark .docs-story {
   color: white !important;
 }
 
+.css-11xgcgt {
+    background: none !important;
+}
+
 /* Material UI component overrides - all using Poppins font */
 .css-x28zkw :where(p:not(.sb-anchor, .sb-unstyled, .sb-unstyled p)),
 .css-14m39zm,

--- a/.storybook/custom-theme.css
+++ b/.storybook/custom-theme.css
@@ -22,7 +22,7 @@ body.theme-dark .docs-story {
 }
 
 .css-11xgcgt {
-    background: none !important;
+    border-top-left-radius: 8px !important;
 }
 
 /* Material UI component overrides - all using Poppins font */


### PR DESCRIPTION
## Description
> Resolve the issues on Element > Show code button is overlapped.: 
-  **All elements and components. In the dark theme, the ‘Show Code’ button was overlapping and has been fixed.**

## Screenshots :
 
<img width="1920" height="1025" alt="image" src="https://github.com/user-attachments/assets/ca067e53-db09-4978-9fea-9f2f8108e216" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes