### PR TITLE
Resolved Bug 3124 and 3538 : Design System > Component > Product tour > and > AIChatBox > Text is not display and hovering effect is different in dark and light mode and ai chat box alignment is not proper. 

### DIFF
--- a/raaghu-components/rds-comp-ai-typing-section/rds-comp-ai-typing-section.scss
+++ b/raaghu-components/rds-comp-ai-typing-section/rds-comp-ai-typing-section.scss
@@ -289,6 +289,7 @@
     &__action-button {
       flex: 1 1 calc((100% - var(--rds-spacing-xs, 6px)) / 2);
       min-width: 0;
+      margin-right: 5px;
     }
 
     &__autocomplete {

--- a/raaghu-elements/rds-app-bar/rds-app-bar.scss
+++ b/raaghu-elements/rds-app-bar/rds-app-bar.scss
@@ -1415,18 +1415,6 @@
   }
 }
 
-.MuiButton-root {
-  @media (max-width: 420px) {
-    padding: 6px 12px !important;
-    font-size: 13px !important;
-  }
-  
-  @media (max-width: 320px) {
-    padding: 4px 8px !important;
-    font-size: 12px !important;
-  }
-}
-
 .MuiAvatar-root {
   @media (max-width: 420px) {
     width: 28px !important;


### PR DESCRIPTION
## Description
> Resolve the issues on Design System: 
-  **Product tour**
- **AiChatBox**
> Add a 5px right margin to the action button in rds-comp-ai-typing-section to improve spacing between buttons. Remove the global .MuiButton-root mobile responsive overrides from rds-app-bar.scss to avoid leaking component-specific styles and rely on component-scoped responsive rules instead.
## Screenshots :
 
<img width="1892" height="961" alt="image" src="https://github.com/user-attachments/assets/13e840d6-9bff-4a1d-a379-512b063cdd9a" />
<img width="1893" height="972" alt="image" src="https://github.com/user-attachments/assets/9556964a-8b5e-49c9-b40d-6f0eb06b7537" />
<img width="1896" height="967" alt="image" src="https://github.com/user-attachments/assets/5b5da89f-3c8e-4f05-bfb4-1c5e0f897e48" />
<img width="1918" height="970" alt="image" src="https://github.com/user-attachments/assets/b67c2477-7275-42fb-b5d9-0e10f427ef2d" />
<img width="1916" height="966" alt="image" src="https://github.com/user-attachments/assets/2926dda5-5dd3-4292-b925-f01cf024beab" />
<img width="1915" height="965" alt="image" src="https://github.com/user-attachments/assets/4ddda251-c4c3-4062-9bb8-ebfc8d355027" />
<img width="1897" height="968" alt="image" src="https://github.com/user-attachments/assets/f9f1e7cc-fea1-47fb-aa84-0db8747f4124" />
<img width="1918" height="971" alt="image" src="https://github.com/user-attachments/assets/75bb08f1-ed3c-4e48-bc2f-ce5e4ab56e37" />
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes