### PR TITLE
Resolved Bug 3582 and 3616 : Design System > Elements > Backdrop > With Custom Content & Interactive story children control input box is highlighted red color. and Element > Toggle Button > Large > Small Mobile > left border missing.

### DIFF
--- a/raaghu-elements/rds-backdrop/rds-backdrop.scss
+++ b/raaghu-elements/rds-backdrop/rds-backdrop.scss
@@ -1,6 +1,3 @@
-// RDS Backdrop Component Styles
-// Modal backdrop overlay
-
 .rds-backdrop {
   display: flex;
   align-items: center;
@@ -26,13 +23,11 @@
     pointer-events: none;
   }
 
-  // Dark theme support for better backdrop visibility
   .dark-theme &,
   [data-theme="dark"] & {
     background-color: rgba(128, 128, 128, 0.4);
   }
 
-  // Loading spinner visibility in dark theme
   .MuiCircularProgress-root {
     color: var(--rds-text-primary, #000);
     

--- a/raaghu-elements/rds-backdrop/rds-backdrop.stories.tsx
+++ b/raaghu-elements/rds-backdrop/rds-backdrop.stories.tsx
@@ -67,12 +67,7 @@ export const Loading: Story = {
 export const WithCustomContent: Story = {
   args: {
     open: true,
-    children: (
-      <div style={{ color: 'white', textAlign: 'center' }}>
-        <h2>Custom Content</h2>
-        <p>This is a custom backdrop content</p>
-      </div>
-    ),
+    children: 'This is a custom backdrop content',
   },
   render: (args) => (
     <div style={{ position: 'relative', minHeight: 300 }}>
@@ -81,7 +76,12 @@ export const WithCustomContent: Story = {
         sx={{
           '&.rds-backdrop': { position: 'absolute' }
         }}
-      />
+      >
+        <div style={{ color: 'white', textAlign: 'center' }}>
+          <h2>Custom Content</h2>
+          <p>{args.children}</p>
+        </div>
+      </RdsBackdrop>
     </div>
   ),
 };
@@ -90,24 +90,22 @@ export const Interactive: Story = {
   args: {
     open: false,
     loading: false,
-    children: (
-      <div style={{ color: 'white', textAlign: 'center' }}>
-        <h2>Click to close</h2>
-        <p>This content can be customized via controls</p>
-      </div>
-    ),
+    children: 'This content can be customized via controls',
   },
   render: (args) => {
     const [open, setOpen] = useState<boolean>(!!args.open);
 
-    // Sync local state with Storybook controls so toggling knobs works.
     useEffect(() => {
       setOpen(!!args.open);
     }, [args.open]);
     
     return (
       <div style={{ position: 'relative', minHeight: 300 }}>
-        <Button variant="contained" onClick={() => setOpen(true)}>
+        <Button 
+          variant="contained" 
+          onClick={() => setOpen(true)}
+          sx={{ color: '#ffffff' }}
+        >
           Show Backdrop
         </Button>
         <RdsBackdrop
@@ -118,7 +116,10 @@ export const Interactive: Story = {
             '&.rds-backdrop': { position: 'absolute' }
           }}
         >
-          {args.children}
+          <div style={{ color: 'white', textAlign: 'center' }}>
+            <h2>Click to close</h2>
+            <p>{args.children}</p>
+          </div>
         </RdsBackdrop>
       </div>
     );

--- a/raaghu-elements/rds-backdrop/rds-backdrop.tsx
+++ b/raaghu-elements/rds-backdrop/rds-backdrop.tsx
@@ -18,25 +18,17 @@ const RdsBackdrop: React.FC<RdsBackdropProps> = ({
   className = '',
   ...props
 }) => {
-  // If `open` is explicitly provided, it takes precedence.
-  // Otherwise, derive visibility from `loading`.
   const isOpen = open !== undefined ? open : loading;
 
-  // When loading, prefer the provided loadingComponent, otherwise fallback to a spinner.
-  // Only render children when not loading.
   const content = loading
     ? (loadingComponent ?? <CircularProgress color="inherit" />)
     : children;
 
-  // Combine our backdrop class with any provided className
   const backdropClassName = `rds-backdrop ${className}`.trim();
 
-  // Remove the hardcoded color for loading spinner to let CSS handle theme-aware colors
   const { sx, ...restProps } = props as { sx?: any } & typeof props;
 
-  // Ensure our custom styles take precedence over Material-UI defaults
   const backdropSx = {
-    // Apply our custom backdrop styles with proper positioning
     '&.rds-backdrop': {
       position: 'fixed',
       top: 0,
@@ -52,7 +44,6 @@ const RdsBackdrop: React.FC<RdsBackdropProps> = ({
       backgroundColor: 'var(--rds-background-overlay, rgba(0, 0, 0, 0.5))',
       color: '#ffffff',
     },
-    // Dark theme override
     '.dark-theme &.rds-backdrop, [data-theme="dark"] &.rds-backdrop': {
       backgroundColor: 'rgba(128, 128, 128, 0.4)',
     },

--- a/raaghu-elements/rds-toggle-button/rds-toggle-button.scss
+++ b/raaghu-elements/rds-toggle-button/rds-toggle-button.scss
@@ -1,9 +1,7 @@
-// RDS Toggle button Component Styles
 .rds-toggle-button {
   display: flex;
   position: relative;
   
-  // Base component styles
   &--horizontal {
     flex-direction: row;
   }
@@ -16,7 +14,6 @@
     display: inline-flex;
   }
 
-  // Custom handling for spaced buttons
   &--spaced {
     .rds-toggle-button__custom-group {
       display: flex;
@@ -28,7 +25,6 @@
       display: inline-flex;
       width: 100%; // Full width for vertical buttons
       
-      // Position-specific styling for horizontal orientation
       &--first .rds-toggle-button__button {
         border-top-right-radius: 0;
         border-bottom-right-radius: 0;
@@ -47,13 +43,11 @@
         border-radius: var(--rds-border-radius-sm); // Keep default border radius
       }
 
-      // Make sure buttons take full width in wrapper
       .rds-toggle-button__button {
         flex: 1;
       }
     }
 
-    // Special handling for vertical orientation
     &.rds-toggle-button--vertical {
       .rds-toggle-button__custom-group {
         flex-direction: column;
@@ -84,7 +78,6 @@
     }
   }
   
-  // Element styles
   &__button {
     transition: var(--rds-transition-base);
     border-radius: var(--rds-border-radius-sm);
@@ -109,7 +102,6 @@
       pointer-events: none;
     }
 
-    // Ensure button style looks good in spaced mode
     &--spaced {
       width: 100%;
       box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
@@ -127,14 +119,12 @@
   }
 }
 
-// Ensure the internal MUI group respects flex and can wrap when needed
 .rds-toggle-button__group {
   display: flex;
   flex-wrap: nowrap; // default (desktop)
   max-width: 100%;
 }
 
-// Size modifiers
 .rds-toggle-button--small .rds-toggle-button__button { 
   font-size: var(--rds-font-size-sm, 0.75rem); 
   padding: var(--rds-spacing-xs,4px) var(--rds-spacing-sm,8px); 
@@ -151,7 +141,6 @@
   min-height: 44px;
 }
 
-// Adjust sizes slightly on very narrow phones to prevent truncation
 @media (max-width:400px){
   .rds-toggle-button--large .rds-toggle-button__button { 
     padding: var(--rds-spacing-sm,8px) var(--rds-spacing-md,12px); 
@@ -160,14 +149,12 @@
   }
 }
 
-// Allow custom spaced group to also wrap when required
 .rds-toggle-button--spaced .rds-toggle-button__custom-group {
   display: flex;
   flex-wrap: nowrap; // default
   max-width: 100%;
 }
 
-// Small mobile responsiveness (prevents horizontal scrollbar at <= 400px width)
 @media (max-width: 400px) {
   .rds-toggle-button { width: 100%; max-width:100%; overflow-x:hidden; }
 
@@ -179,14 +166,12 @@
     max-width:100%;
   }
 
-  // Make every button flex equally so the longest label doesn't force overflow
   .rds-toggle-button__group .MuiToggleButton-root,
   .rds-toggle-button__button { 
     min-width:0; 
     box-sizing:border-box; // keep structural adjustments only
   }
 
-  // Size-specific scaling on very small viewports so control remains distinguishable
   .rds-toggle-button--small .rds-toggle-button__button { 
     font-size: var(--rds-font-size-xs,0.7rem); 
     padding: 4px 6px; 
@@ -202,12 +187,10 @@
 
   .rds-toggle-button__icon { margin-right: 4px !important; }
 
-  // Spaced variant: remove horizontal margins that create overflow
   .rds-toggle-button--spaced .rds-toggle-button__button-wrapper { 
     margin-left: 0 !important; 
   }
 
-  // Spaced + horizontal: prevent each wrapper from forcing 100% width (causes scroll)
   .rds-toggle-button--spaced:not(.rds-toggle-button--vertical) .rds-toggle-button__button-wrapper { 
     width:auto; 
     flex:1 1 50%; // two per row pattern for readability
@@ -222,10 +205,8 @@
     padding:6px 8px; // restore a bit of horizontal spacing to prevent overlap
     box-sizing:border-box;
   }
-  // Ensure flex chain doesn't create min-content overflow
   .rds-toggle-button--spaced .rds-toggle-button__custom-group { min-width:0; flex-wrap:wrap; }
 
-  // 2 + 1 layout for large size groups with exactly 3 options
   .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical):not(.rds-toggle-button--spaced) .rds-toggle-button__group,
   .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical).rds-toggle-button--spaced .rds-toggle-button__custom-group {
     flex-wrap: wrap;
@@ -235,25 +216,41 @@
     flex:1 1 50%;
     max-width:50%;
   }
+  
+  .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical) .MuiToggleButton-root:nth-child(1),
+  .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical) .rds-toggle-button__button-wrapper:nth-child(1) .rds-toggle-button__button {
+    border-top-left-radius: var(--rds-border-radius-sm, 4px) !important;
+    border-top-right-radius: 0 !important;
+    border-bottom-left-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+  }
+  
+  .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical) .MuiToggleButton-root:nth-child(2),
+  .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical) .rds-toggle-button__button-wrapper:nth-child(2) .rds-toggle-button__button {
+    border-top-right-radius: var(--rds-border-radius-sm, 4px) !important;
+    border-top-left-radius: 0 !important;
+    border-bottom-left-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+  }
+  
   .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical) .MuiToggleButton-root:nth-child(3),
   .rds-toggle-button--large-three.rds-toggle-button--large:not(.rds-toggle-button--vertical) .rds-toggle-button__button-wrapper:nth-child(3) .rds-toggle-button__button {
     flex:1 1 100%;
     max-width:100%;
+    border-bottom-left-radius: var(--rds-border-radius-sm, 4px) !important;
+    border-bottom-right-radius: var(--rds-border-radius-sm, 4px) !important;
+    border-top-left-radius: 0 !important;
+    border-top-right-radius: 0 !important;
   }
 
-  // Fallback: if still overflowing for edge locales, allow wrap cleanly
   @supports (flex-wrap: wrap) {
     .rds-toggle-button.is-wrap .rds-toggle-button__group,
     .rds-toggle-button.is-wrap.rds-toggle-button--spaced .rds-toggle-button__custom-group {
       flex-wrap: wrap;
     }
   }
-
 }
 
-
-  // Automatic wrapping variant (added when option count > 3) - MOBILE ONLY (<=600px)
-  // We intentionally restrict wrapping to small screens; tablet & desktop remain single row.
   @media (max-width: 600px) {
     .rds-toggle-button--wrap-mobile .rds-toggle-button__group,
     .rds-toggle-button--wrap-mobile.rds-toggle-button--spaced .rds-toggle-button__custom-group {
@@ -263,7 +260,7 @@
     .rds-toggle-button--wrap-mobile .rds-toggle-button__button {
       flex: 1 1 50%; // two per row
     }
-    // Fix border-radius for first and last buttons in each row (2-row layout)
+   
     .rds-toggle-button--wrap-mobile .MuiToggleButton-root:nth-child(1),
     .rds-toggle-button--wrap-mobile .rds-toggle-button__button-wrapper:nth-child(1) .rds-toggle-button__button {
       border-top-left-radius: var(--rds-border-radius-sm, 4px);
@@ -294,7 +291,6 @@
     }
   }
 
-// Large mobile / small handset landscape (covers widths like 414px iPhone and up to small tablets)
 @media (min-width:401px) and (max-width: 600px) {
   .rds-toggle-button { width:100%; max-width:100%; }
 
@@ -314,23 +310,77 @@
     box-sizing:border-box; 
   }
 
-  // Spaced variant margin neutralization to avoid overflow
   .rds-toggle-button--spaced .rds-toggle-button__button-wrapper { margin-left:0 !important; }
 }
 
-@media (max-width: 400px) {
-.css-1qb8o-MuiToggleButtonGroup-root {
-  border-radius: 0px !important;
-}
-
-}
-
-.css-1qb8o-MuiToggleButtonGroup-root .MuiToggleButtonGroup-lastButton.Mui-disabled, .css-1qb8o-MuiToggleButtonGroup-root .MuiToggleButtonGroup-middleButton.Mui-disabled {
-    border: 1px solid #646464;
-}
-
-.css-1qb8o-MuiToggleButtonGroup-root .MuiToggleButtonGroup-lastButton, .css-1qb8o-MuiToggleButtonGroup-root .MuiToggleButtonGroup-middleButton {
-    margin-left: 0px !important;
-    border: 1px solid #646464 !important;
+.rds-toggle-button__group {
+  .MuiToggleButtonGroup-grouped {
+    border: 1px solid rgba(0, 0, 0, 0.23) !important;
+    margin-left: 0 !important;
+    border-left-width: 1px !important;
     
+    &.Mui-disabled {
+      border: 1px solid rgba(100, 100, 100, 0.3) !important;
+    }
+    
+    &.Mui-selected {
+      border-color: currentColor !important;
+      z-index: 1;
+    }
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .rds-toggle-button__group .MuiToggleButtonGroup-grouped {
+    border: 1px solid rgba(255, 255, 255, 0.23) !important;
+    border-left-width: 1px !important;
+    
+    &.Mui-disabled {
+      border: 1px solid rgba(100, 100, 100, 0.5) !important;
+    }
+    
+    &.Mui-selected {
+      border-color: currentColor !important;
+    }
+  }
+}
+
+.dark-theme,
+[data-theme="dark"],
+.theme-dark,
+body.theme-dark,
+html.theme-dark {
+  .rds-toggle-button__group .MuiToggleButtonGroup-grouped {
+    border: 1px solid rgba(255, 255, 255, 0.23) !important;
+    border-left-width: 1px !important;
+    margin-left: 0 !important;
+    
+    &.Mui-disabled {
+      border: 1px solid rgba(100, 100, 100, 0.5) !important;
+    }
+    
+    &.Mui-selected {
+      border-color: currentColor !important;
+    }
+  }
+}
+
+@media (max-width: 400px) {
+  .rds-toggle-button__group .MuiToggleButtonGroup-grouped {
+    border: 1px solid rgba(0, 0, 0, 0.23) !important;
+    
+    &:not(:first-of-type) {
+      border-left: 1px solid rgba(0, 0, 0, 0.23) !important;
+    }
+  }
+  
+  @media (prefers-color-scheme: dark) {
+    .rds-toggle-button__group .MuiToggleButtonGroup-grouped {
+      border: 1px solid rgba(255, 255, 255, 0.23) !important;
+      
+      &:not(:first-of-type) {
+        border-left: 1px solid rgba(255, 255, 255, 0.23) !important;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Description
> Resolve the issues on Design System: 
-  **Backdrop**
- **Toggle Button**
> This pull request focuses on improving code clarity by removing redundant comments and enhancing the maintainability and consistency of styles for the `rds-backdrop` and `rds-toggle-button` components. The most significant changes include the removal of unnecessary comments from SCSS files, 
> Updates to the Storybook stories for more flexible custom content handling, and a comprehensive refactor and expansion of the toggle button SCSS to ensure robust, theme-aware, and responsive styling.
## Screenshots :
 
<img width="1918" height="962" alt="image" src="https://github.com/user-attachments/assets/55f82950-2675-40ef-a497-a0dc2ca4348b" />
<img width="1918" height="966" alt="image" src="https://github.com/user-attachments/assets/7073067c-9d9f-44b4-9961-118a74c34082" />
<img width="1918" height="968" alt="image" src="https://github.com/user-attachments/assets/cb090719-785d-4561-8281-f83b4c9359ab" />
<img width="1916" height="970" alt="image" src="https://github.com/user-attachments/assets/2afb4242-368d-45af-8dce-21b3ba9467ff" />
<img width="1916" height="966" alt="image" src="https://github.com/user-attachments/assets/ea6e0fb2-8701-42da-934e-58946934e727" />
<img width="1918" height="966" alt="image" src="https://github.com/user-attachments/assets/baeb18d2-aad4-4f29-b766-858db5fe310f" />
<img width="1917" height="972" alt="image" src="https://github.com/user-attachments/assets/2b604ad7-de85-402e-8c4b-5f5371c7dfb0" />
<img width="1918" height="970" alt="image" src="https://github.com/user-attachments/assets/ef2746a8-08b4-4492-a757-7261cb817828" />
<img width="1918" height="967" alt="image" src="https://github.com/user-attachments/assets/ea43e3a4-d5c2-45e6-82e3-3bb4b76d6e57" />
<img width="1918" height="971" alt="image" src="https://github.com/user-attachments/assets/49163b92-3926-4990-ae60-cdc00db69a05" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
