### PR TITLE
Resolved New Bug -3657 - Elements > skeleton > card-skeleton >height-red border

### DIFF
--- a/raaghu-elements/rds-skeleton/rds-skeleton.stories.tsx
+++ b/raaghu-elements/rds-skeleton/rds-skeleton.stories.tsx
@@ -122,7 +122,7 @@ export const CardSkeleton: Story = {
   },
   args: {
     width: "100%",
-    height: 140,
+    height: "140px",
     animated: true,
   },
   render: (args) => (


### PR DESCRIPTION
## Description
> Resolved the issues on skeleton > card-skeleton >height control -displayed on red border.
## Screenshots :
 
<img width="1913" height="962" alt="image" src="https://github.com/user-attachments/assets/3b1712d9-4928-4df2-ae3a-27dbc4352158" />

 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CardSkeleton story example to use string format with CSS units for the height value, improving consistency with component specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->