### PR TITLE
Resolved Issue 733 : Storybook > Application Shells > Basic >Small and Large mobile view side nav is not open

### DIFF
--- a/raaghu-layouts/rds-comp-app-shell/rds-comp-app-shell.scss
+++ b/raaghu-layouts/rds-comp-app-shell/rds-comp-app-shell.scss
@@ -1065,7 +1065,7 @@ nav#sidebar.bd-links.text-capitalize.sidebar.overflow-x-hidden.overflow-y-auto.p
       top: 68px;
       left: 0;
       right: 0;
-      bottom: 45px;
+      bottom: 0;
       display: flex;
       align-items: center;
       justify-content: center;


### PR DESCRIPTION
## Description
> fixed shell sidebar issue & after horizontal scroll sidebar shows in right 

## Screenshots :
<img width="1356" height="872" alt="image" src="https://github.com/user-attachments/assets/bcddc768-a0ba-414f-a452-b72cd111648e" />

<img width="1392" height="840" alt="image" src="https://github.com/user-attachments/assets/f1cc4c26-c88a-4d73-bb39-13f6195d792b" />




 
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined mobile side navigation positioning to improve layout alignment on smaller screens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->