### PR TITLE
Resolved Bug 3808 : Design System > Components> React 18 > Text Editor > Dark theme state control is not working.

### DIFF
--- a/raaghu-components/rds-comp-map/rds-comp-map.scss
+++ b/raaghu-components/rds-comp-map/rds-comp-map.scss
@@ -183,11 +183,9 @@
   }
 
   &--heatmap {
-    background: linear-gradient(0deg, var(--rds-comp-map-heatmap-0), var(--rds-comp-map-heatmap-0)),
-      radial-gradient(50.38% 50.38% at 30.5% 6.53%, var(--rds-comp-map-heatmap-1) 0%, var(--rds-comp-map-heatmap-2) 33%, var(--rds-comp-map-heatmap-3) 67.18%, var(--rds-comp-map-heatmap-4) 100%),
-      radial-gradient(61.69% 61.69% at 78.5% 19.32%, var(--rds-comp-map-heatmap-5) 0%, var(--rds-comp-map-heatmap-6) 38.26%, var(--rds-comp-map-heatmap-7) 100%),
-      radial-gradient(36.18% 63.42% at 35.64% 37.56%, var(--rds-comp-map-heatmap-8) 0%, var(--rds-comp-map-heatmap-9) 44.15%, rgba(181, 228, 62, 0) 100%),
-      radial-gradient(18.75% 43.04% at 26.5% 80.97%, var(--rds-comp-map-heatmap-10) 0%, var(--rds-comp-map-heatmap-11) 50%, rgba(252, 71, 3, 0) 100%);
+    /* Heatmap colors are applied to country fills only; keep container on theme background */
+    background-color: var(--rds-bg, transparent) !important;
+    background-image: none;
 
     .rds-comp-map__label {
       color: var(--rds-text, #333);

--- a/raaghu-components/rds-comp-text-editor/rds-comp-text-editor.scss
+++ b/raaghu-components/rds-comp-text-editor/rds-comp-text-editor.scss
@@ -313,6 +313,14 @@ body.dark-theme .rds-comp-text-editor {
   border-color: var(--rds-border-default, rgba(255, 255, 255, 0.18));
   color: var(--rds-neutral-0, #fff);
 
+  &.rds-comp-text-editor--active {
+    border-color: var(--rds-color-primary, var(--rds-primary-main));
+  }
+
+  &.rds-comp-text-editor--error {
+    border-color: var(--rds-color-error, var(--rds-error-main));
+  }
+
   &.rds-comp-text-editor--disabled {
     background-color: var(--rds-color-disabled-surface-dark, #2b2f3a);
     border-color: var(--rds-border-default, rgba(255, 255, 255, 0.16));


### PR DESCRIPTION
## Description
> Resolve the issues on Element Radio button unable to select: 
-  **Text Editor**
-  **Map**
-  **Typing Section**
> Make the changes to stories file.
> Make the changes to scss and tsx files.
## Screenshots :
 
<img width="1918" height="967" alt="image" src="https://github.com/user-attachments/assets/3e083b43-4a58-4ab0-b6a4-1d53808b9ff4" />
<img width="1918" height="967" alt="image" src="https://github.com/user-attachments/assets/38b0c615-4601-4a57-b332-e4ecb64bbaeb" />
<img width="1919" height="964" alt="Screenshot 2026-07-02 112200" src="https://github.com/user-attachments/assets/be14e103-e88b-4279-ac5b-013abb367d02" />
<img width="1919" height="967" alt="Screenshot 2026-07-02 112218" src="https://github.com/user-attachments/assets/eac370f4-b804-4372-9136-8316c69962fd" />
<img width="1918" height="970" alt="image" src="https://github.com/user-attachments/assets/8aa4a65d-623a-4677-9f9c-91f1096a86b4" />
<img width="1918" height="962" alt="image" src="https://github.com/user-attachments/assets/b4b2d51c-2a05-4522-a900-8aee221d3506" />
<img width="1918" height="968" alt="image" src="https://github.com/user-attachments/assets/626df426-d346-4f2a-a3da-3d2312da4416" />
<img width="1918" height="960" alt="image" src="https://github.com/user-attachments/assets/4a7850fd-313a-4cc1-bbd2-86b6a6c3c94e" />
 
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changess